### PR TITLE
Adopt `anyAppleOS` availability and drop the custom availability macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,42 +16,13 @@
 
 import PackageDescription
 
-// Availability Macros
-
-let availabilityTags: [_Availability] = [
-    _Availability("SwiftTLS"),
-]
-let versionNumbers = ["0.1.0"]
-
-// Availability Macro Utilities
-enum _OSAvailability: String {
-    // The OS versions in which `SwiftTLS 0.1.0` APIs first became available.
-    case alwaysAvailable = "macOS 26, iOS 26, tvOS 26, watchOS 26, visionOS 26"
-    // Use 10000 for future availability to avoid compiler magic around the 9999 version number but ensure it is greater than 9999"
-    case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000, visionOS 10000"
-}
-
-struct _Availability {
-    let name: String
-    let osAvailability: _OSAvailability
-
-    init(_ name: String, osAvailability: _OSAvailability = .alwaysAvailable) {
-        self.name = name
-        self.osAvailability = osAvailability
-    }
-}
-let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
-    availabilityTags.map {
-        .enableExperimentalFeature("AvailabilityMacro=\($0.name) \(version):\($0.osAvailability.rawValue)")
-    }
-}
-
 var packageDependencies = [PackageDescription.Package.Dependency]()
 var targetDependencies = [PackageDescription.Target.Dependency]()
 
-var settings: [SwiftSetting]? = [
+var settings: [SwiftSetting] = [
     // Add build settings here
     .enableExperimentalFeature("Lifetimes"),
+    .enableExperimentalFeature("AnyAppleOSAvailability"),
 ]
 
 #if os(Linux)
@@ -89,12 +60,12 @@ let package = Package(
         .target(
             name: "SwiftTLS",
             dependencies: targetDependencies,
-            swiftSettings: availabilityMacros + (settings ?? [])
+            swiftSettings: settings
         ),
         .testTarget(
             name: "SwiftTLSTests",
             dependencies: ["SwiftTLS"],
-            swiftSettings: availabilityMacros + (settings ?? [])
+            swiftSettings: settings
         ),
     ]
 )

--- a/Sources/ArraySpanUtilities.swift
+++ b/Sources/ArraySpanUtilities.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Array where Element == UInt8 {
     /// Creates an array by copying the bytes of the given raw span.
     ///
@@ -27,7 +27,7 @@ extension Array where Element == UInt8 {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InlineArray where Element == UInt8 {
     /// Creates an inline array by copying the bytes of the given raw span.
     ///
@@ -42,7 +42,7 @@ extension InlineArray where Element == UInt8 {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Hasher {
     mutating func combine(bytes: RawSpan) {
         bytes.withUnsafeBytes { buffer in
@@ -51,7 +51,7 @@ extension Hasher {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InlineArray where Element: Equatable {
     static func ==(lhs: Self, rhs: Self) -> Bool {
         for i in lhs.indices {
@@ -64,7 +64,7 @@ extension InlineArray where Element: Equatable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension OutputRawSpan {
     /// Appends the contents of the given raw span to this output span.
     mutating func append(contentsOf bytes: RawSpan) {
@@ -74,7 +74,7 @@ extension OutputRawSpan {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension RawSpan {
     subscript(index: Int) -> UInt8 {
         unsafeLoad(fromByteOffset: index, as: UInt8.self)

--- a/Sources/ByteBuffer.swift
+++ b/Sources/ByteBuffer.swift
@@ -28,7 +28,7 @@ extension Data {
 ///
 /// This is not a truly hardened version of NIO's ByteBuffer. It lacks some flexibility, but it's
 /// good enough for what we need.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ByteBuffer {
     private var backingData: Data
     private(set) var readerIndex: Data.Index
@@ -218,7 +218,7 @@ struct ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeVariableLengthVector<LengthField: FixedWidthInteger>(
@@ -283,7 +283,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer: Hashable {
     static func ==(lhs: ByteBuffer, rhs: ByteBuffer) -> Bool {
         return lhs.readableBytesView == rhs.readableBytesView
@@ -294,7 +294,7 @@ extension ByteBuffer: Hashable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     /// Execute the given `body` function with an input buffer that can access
     /// the readable part of the byte buffer. Bytes consumed from the input

--- a/Sources/Callbacks.swift
+++ b/Sources/Callbacks.swift
@@ -18,7 +18,7 @@ import Foundation
 
 // Result type for async computations applied to the handshaker.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct PendingAsyncResult: Sendable {
     enum AsyncResult {
         case certificate(CertificateResult)
@@ -43,7 +43,7 @@ public struct PendingAsyncResult: Sendable {
 
 // List of opaque certificate data.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct CertificateList: Sendable, Hashable {
     public var type: CertificateType
     public var entries: [Data]
@@ -56,7 +56,7 @@ public struct CertificateList: Sendable, Hashable {
 
 // Information offered by the client during the handshake.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct PeerOffer: Sendable, Hashable {
     public var certificateTypes: [CertificateType]
     public var signatureAlgorithms: [UInt16]
@@ -74,7 +74,7 @@ public struct PeerOffer: Sendable, Hashable {
 // The result waiting indicates asynchronous work in the callback.
 // The reason given for an unavailable certificate will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public enum CertificateResult: Sendable, Hashable {
     case available(CertificateList)
     case unavailable(reason: String)
@@ -83,7 +83,7 @@ public enum CertificateResult: Sendable, Hashable {
 
 // Information passed into the callback.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct CertificateInfo: Sendable {
     public var peerOffer: PeerOffer
     public var deliverResult: (@Sendable (CertificateResult) -> Void)?
@@ -99,13 +99,13 @@ public struct CertificateInfo: Sendable {
 // Note: This callback must either return a result directly (available, unavailable)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public typealias CertificateCallback = @Sendable (CertificateInfo) -> CertificateResult
 
 // The result waiting indicates asynchronous work in the callback.
 // The reason given for an unavailable signature will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public enum SignatureResult: Sendable, Hashable {
     case available(signature: Data, algorithm: UInt16)
     case unavailable(reason: String)
@@ -114,7 +114,7 @@ public enum SignatureResult: Sendable, Hashable {
 
 // Information passed into the callback.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct SignatureInfo: Sendable {
     public var transcriptHash: Data
     public var peerOffer: PeerOffer
@@ -132,12 +132,12 @@ public struct SignatureInfo: Sendable {
 // Note: This callback must either return a result directly (available, unavailable)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public typealias SignatureCallback = @Sendable (SignatureInfo) -> SignatureResult
 
 // Bundles the callbacks for the server to customize the certificate messages.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct AsyncAuthenticator: Sendable {
     public var supportedCertificateTypes: [CertificateType]
     public var getCertificateChain: CertificateCallback
@@ -157,7 +157,7 @@ public struct AsyncAuthenticator: Sendable {
 // Waiting indicates ongoing asynchronous work in the callback.
 // The reason given for an invalid verification will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public enum VerificationResult: Sendable, Hashable {
     case valid
     case invalid(reason: String)
@@ -166,7 +166,7 @@ public enum VerificationResult: Sendable, Hashable {
 
 // Information to verify the certificates and signature presented by the peer.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct VerificationInfo: Sendable {
     public var certificates: CertificateList
     public var signatureAlgorithm: UInt16
@@ -191,11 +191,11 @@ public struct VerificationInfo: Sendable {
 // Note: This callback must either return a result directly (valid, invalid)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public typealias VerificationCallback = @Sendable (VerificationInfo) -> VerificationResult
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct AsyncVerifier: Sendable {
     public var availableCertificateTypes: [CertificateType]
     public var verifyHandshake: VerificationCallback

--- a/Sources/Cryptography/KeyScheduler.swift
+++ b/Sources/Cryptography/KeyScheduler.swift
@@ -34,7 +34,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.SessionKeyManage
 
 // Wrapper around SessionKeyManager that only exposes functions a client should
 // need to call to help avoid invalid transitions.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ClientSessionKeyManager<HF: HashFunction> {
     private var sessionKeyManager: SessionKeyManager<HF>
 
@@ -135,7 +135,7 @@ struct ClientSessionKeyManager<HF: HashFunction> {
 
 // Wrapper around SessionKeyManager that only exposes functions a server should
 // need to call to help avoid invalid transitions.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ServerSessionKeyManager<HF: HashFunction> {
     private var sessionKeyManager: SessionKeyManager<HF>
 
@@ -220,7 +220,7 @@ struct ServerSessionKeyManager<HF: HashFunction> {
 /// The TLS 1.3 key schedule builds out a ratchet of keys and secrets for various purposes.
 /// This object encapsulates the current state in the key schedule and provides access to the
 /// various secrets for the rest of the code to use.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate struct SessionKeyManager<HF: HashFunction> {
 
     /// The running state of the key manager.
@@ -523,7 +523,7 @@ fileprivate struct SessionKeyManager<HF: HashFunction> {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension SessionKeyManager {
     fileprivate enum State {
         /// The dialogue has not yet begun; no keying material is available.
@@ -561,7 +561,7 @@ extension SessionKeyManager {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension SessionKeyManager.State {
     fileprivate struct EarlySecret {
         /// The current state of the transcript hash.

--- a/Sources/Cryptography/PrivateKey.swift
+++ b/Sources/Cryptography/PrivateKey.swift
@@ -24,7 +24,7 @@ import CryptoKit
 /// A generic wrapper over the supported private-key types.
 ///
 /// Loosely based on the implementation in Swift Certificates.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct PrivateKey {
     var backing: BackingPrivateKey
 
@@ -94,10 +94,10 @@ struct PrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PrivateKey: Hashable {}
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PrivateKey: CustomStringConvertible {
     var description: String {
         switch self.backing {
@@ -115,13 +115,13 @@ extension PrivateKey: CustomStringConvertible {
 
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public typealias SwiftTLSSignatureScheme = UInt16
 
 /// A callback that accepts the bytes to sign and the negotiated TLS signature scheme,
 /// and returns the signature, or `nil` when signing fails.
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public typealias SwiftTLSRefKeySignCallback = (Data, SwiftTLSSignatureScheme) -> Data?
 
 /// The underlying key types supported by `SwiftTLSOpaqueReferenceKey`.
@@ -132,7 +132,7 @@ enum SwiftTLSOpaqueReferenceKeyType: Sendable {
 /// A generic private-key type that lets a caller produce signatures over data using any key
 /// the caller can access.
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct SwiftTLSOpaqueReferenceKey {
     let publicKey: PublicKey
     let sign: SwiftTLSRefKeySignCallback
@@ -167,7 +167,7 @@ public struct SwiftTLSOpaqueReferenceKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PrivateKey {
     enum BackingPrivateKey: Hashable {
         case p256(P256.Signing.PrivateKey)

--- a/Sources/Cryptography/PublicKey.swift
+++ b/Sources/Cryptography/PublicKey.swift
@@ -47,13 +47,13 @@ extension PublicKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: Hashable {}
 
-@available(SwiftTLS 0.1.0, *)
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: Sendable {}
 
-@available(SwiftTLS 0.1.0, *)
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: CustomStringConvertible {
     var description: String {
         switch self.backing {

--- a/Sources/DataUtilities.swift
+++ b/Sources/DataUtilities.swift
@@ -16,7 +16,7 @@
 import Foundation
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Data {
     /// Creates a `Data` instance by copying the raw bytes from the given span.
     init(copying bytes: RawSpan) {

--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -16,7 +16,7 @@
 typealias CryptoKitMetaError = any Error
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum TLSError: Error, Equatable {
     case truncatedMessage
     case excessBytes
@@ -66,7 +66,7 @@ enum TLSError: Error, Equatable {
     case refKeySigningFailure
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension TLSError {
     static func wrappingCryptoError<Return, E:Error>(_ block: () throws(E) -> Return) throws(TLSError) -> Return {
         do {

--- a/Sources/Extensions/Extension.swift
+++ b/Sources/Extensions/Extension.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum Extension {
     case serverName(ServerName)
     case supportedGroups(SupportedGroups)
@@ -63,10 +63,10 @@ enum Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readExtension(messageType: HandshakeType, helloRetryRequest: Bool) throws(TLSError) -> Extension? {
         guard let type = self.readExtensionType() else {
@@ -121,7 +121,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeExtension(_ ext: Extension) -> Int {

--- a/Sources/Extensions/ExtensionType.swift
+++ b/Sources/Extensions/ExtensionType.swift
@@ -20,7 +20,7 @@ struct ExtensionType: RawRepresentable, Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ExtensionType {
     static let serverName = ExtensionType(rawValue: 0)
 
@@ -49,10 +49,10 @@ extension ExtensionType {
     static let ticketRequest = ExtensionType(rawValue: 58)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ExtensionType: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ExtensionType: CustomStringConvertible {
     var description: String {
         switch self {
@@ -88,14 +88,14 @@ extension ExtensionType: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readExtensionType() -> ExtensionType? {
         return self.readInteger().map { ExtensionType(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeExtensionType(_ type: ExtensionType) -> Int {

--- a/Sources/Extensions/ExtensionType.swift
+++ b/Sources/Extensions/ExtensionType.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
 struct ExtensionType: RawRepresentable, Sendable {
     var rawValue: UInt16
 

--- a/Sources/Extensions/Extensions+ALPN.swift
+++ b/Sources/Extensions/Extensions+ALPN.swift
@@ -16,7 +16,7 @@
 import Foundation
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum ApplicationLayerProtocolNegotiation {
         case offer([String])
@@ -24,10 +24,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.ApplicationLayerProtocolNegotiation: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeALPN(_ alpn: Extension.ApplicationLayerProtocolNegotiation) -> Int {
@@ -47,7 +47,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readALPN(messageType: HandshakeType) throws(TLSError) -> Extension.ApplicationLayerProtocolNegotiation {
         switch messageType {

--- a/Sources/Extensions/Extensions+CertificateType.swift
+++ b/Sources/Extensions/Extensions+CertificateType.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum CertificateTypeExt {
         case offer([CertificateType])
@@ -20,10 +20,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.CertificateTypeExt: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeCertificateType(_ certificateType: Extension.CertificateTypeExt) -> Int {
@@ -41,7 +41,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readCertificateType(messageType: HandshakeType) throws(TLSError) -> Extension.CertificateTypeExt {
         switch messageType {

--- a/Sources/Extensions/Extensions+EarlyData.swift
+++ b/Sources/Extensions/Extensions+EarlyData.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     struct EarlyData {
         // Will be `nil` when used in ClientHello/EncryptedExtensions, will not be zero otherwise.
@@ -20,10 +20,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.EarlyData: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeEarlyDataExtension(_ earlyData: Extension.EarlyData) -> Int {
@@ -35,7 +35,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readEarlyDataExtension(messageType: HandshakeType) throws(TLSError) -> Extension.EarlyData {
         switch messageType {

--- a/Sources/Extensions/Extensions+KeyShare.swift
+++ b/Sources/Extensions/Extensions+KeyShare.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum KeyShare {
         case clientHello([KeyShareEntry])
@@ -21,10 +21,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.KeyShare: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.KeyShare {
     struct KeyShareEntry {
         var group: NamedGroup
@@ -37,17 +37,17 @@ extension Extension.KeyShare {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.KeyShare.KeyShareEntry: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.KeyShare.KeyShareEntry: CustomStringConvertible {
     var description: String {
         "KeyShareEntry(group: \(self.group), keyExchange: \(self.keyExchange.readableBytes) bytes)"
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeKeyShare(_ versions: Extension.KeyShare) -> Int {
@@ -76,7 +76,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readKeyShareEntry() -> Extension.KeyShare.KeyShareEntry? {
         guard let group = self.readNamedGroup() else {

--- a/Sources/Extensions/Extensions+PreSharedKey.swift
+++ b/Sources/Extensions/Extensions+PreSharedKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum PreSharedKey {
         case clientHello(OfferedPSKs)
@@ -20,7 +20,7 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey {
     struct OfferedPSKs {
         var identities: [PSKIdentity]
@@ -29,7 +29,7 @@ extension Extension.PreSharedKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey.OfferedPSKs {
     struct PSKIdentity {
         var identity: ByteBuffer
@@ -38,26 +38,26 @@ extension Extension.PreSharedKey.OfferedPSKs {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey.OfferedPSKs {
     struct PSKBinderEntry {
         var serializedBinder: ByteBuffer
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey.OfferedPSKs: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey.OfferedPSKs.PSKIdentity: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKey.OfferedPSKs.PSKBinderEntry: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readPSKIdentity() throws(TLSError) -> Extension.PreSharedKey.OfferedPSKs.PSKIdentity? {
         guard let identity: ByteBuffer = try? self.readVariableLengthVector(lengthFieldType: UInt16.self, { buffer in
@@ -138,7 +138,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writePreSharedKey(_ psk: Extension.PreSharedKey) -> Int {

--- a/Sources/Extensions/Extensions+PreSharedKeyKexModes.swift
+++ b/Sources/Extensions/Extensions+PreSharedKeyKexModes.swift
@@ -12,14 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     struct PreSharedKeyKexModes {
         var modes: [Mode]
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKeyKexModes {
     struct Mode: RawRepresentable, Hashable {
         var rawValue: UInt8
@@ -33,10 +33,10 @@ extension Extension.PreSharedKeyKexModes {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.PreSharedKeyKexModes: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readPreSharedKeyKexModes(messageType: HandshakeType) throws(TLSError) -> Extension.PreSharedKeyKexModes {
         switch messageType {
@@ -60,7 +60,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writePreSharedKeyKexModes(_ modes: Extension.PreSharedKeyKexModes) -> Int {

--- a/Sources/Extensions/Extensions+QUICTransportParameters.swift
+++ b/Sources/Extensions/Extensions+QUICTransportParameters.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     // For consistency with other implementations, we don't introspect this field at all.
     struct QUICTransportParameters {
@@ -20,10 +20,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.QUICTransportParameters: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readQUICTransportParameters(messageType: HandshakeType) throws(TLSError) -> Extension.QUICTransportParameters {
         switch messageType {
@@ -36,7 +36,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeQUICTransportParameters(_ transportParameters: Extension.QUICTransportParameters) -> Int {

--- a/Sources/Extensions/Extensions+ServerName.swift
+++ b/Sources/Extensions/Extensions+ServerName.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum ServerName {
         case clientHello(Names)
@@ -21,7 +21,7 @@ extension Extension {
 
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.ServerName {
     struct Names {
         var hostName: ByteBuffer
@@ -30,13 +30,13 @@ extension Extension.ServerName {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.ServerName: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.ServerName.Names: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readServerName(messageType: HandshakeType) throws(TLSError) -> Extension.ServerName {
         switch messageType {
@@ -105,7 +105,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeServerName(_ serverName: Extension.ServerName) -> Int {

--- a/Sources/Extensions/Extensions+SignatureAlgorithms.swift
+++ b/Sources/Extensions/Extensions+SignatureAlgorithms.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     struct SignatureAlgorithms {
         var schemes: [SignatureScheme]
@@ -23,10 +23,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.SignatureAlgorithms: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readSignatureAlgorithms(messageType: HandshakeType) throws(TLSError) -> Extension.SignatureAlgorithms {
         switch messageType {
@@ -54,7 +54,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeSignatureAlgorithms(_ algorithms: Extension.SignatureAlgorithms) -> Int {

--- a/Sources/Extensions/Extensions+SupportedGroups.swift
+++ b/Sources/Extensions/Extensions+SupportedGroups.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     struct SupportedGroups {
         var groups: [NamedGroup]
@@ -23,10 +23,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.SupportedGroups: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readSupportedGroups(messageType: HandshakeType) throws(TLSError) -> Extension.SupportedGroups {
         switch messageType {
@@ -54,7 +54,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeSupportedGroups(_ groups: Extension.SupportedGroups) -> Int {

--- a/Sources/Extensions/Extensions+SupportedVersions.swift
+++ b/Sources/Extensions/Extensions+SupportedVersions.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum SupportedVersions {
         case offer([ProtocolVersion])
@@ -20,10 +20,10 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.SupportedVersions: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readSupportedVersions(messageType: HandshakeType) throws(TLSError) -> Extension.SupportedVersions {
         switch messageType {
@@ -57,7 +57,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeSupportedVersions(_ versions: Extension.SupportedVersions) -> Int {

--- a/Sources/Extensions/Extensions+TicketRequest.swift
+++ b/Sources/Extensions/Extensions+TicketRequest.swift
@@ -23,7 +23,6 @@ extension Extension {
 @available(SwiftTLS 0.1.0, *)
 extension Extension.TicketRequest: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
 struct ClientTicketRequest: Hashable, CustomStringConvertible {
     var newSessionCount: UInt8
     var resumptionCount: UInt8

--- a/Sources/Extensions/Extensions+TicketRequest.swift
+++ b/Sources/Extensions/Extensions+TicketRequest.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension {
     enum TicketRequest {
         case clientHello(ClientTicketRequest)
@@ -20,7 +20,7 @@ extension Extension {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.TicketRequest: Hashable { }
 
 struct ClientTicketRequest: Hashable, CustomStringConvertible {
@@ -37,7 +37,7 @@ struct ClientTicketRequest: Hashable, CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.TicketRequest {
     struct ServerTicketRequestHint {
         var expectedCount: UInt8
@@ -48,17 +48,17 @@ extension Extension.TicketRequest {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.TicketRequest.ServerTicketRequestHint: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Extension.TicketRequest.ServerTicketRequestHint: CustomStringConvertible {
     var description: String {
         return "TicketRequest(newSessionCount: \(self.expectedCount))"
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readTicketRequestExtension(messageType: HandshakeType) throws(TLSError) -> Extension.TicketRequest {
         switch messageType {
@@ -79,7 +79,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeTicketRequestExtension(_ ticketRequest: Extension.TicketRequest) -> Int {

--- a/Sources/Handshake/ExternalPreSharedKey.swift
+++ b/Sources/Handshake/ExternalPreSharedKey.swift
@@ -21,7 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct EPSK {
     let externalIdentity: ByteBuffer
     let epsk: SymmetricKey
@@ -61,7 +61,7 @@ struct EPSK {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct TLSKDFIdentifier: Sendable {
     public let rawValue: UInt16
     public let outputLength: Int
@@ -83,28 +83,28 @@ struct TLSKDFIdentifier: Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension TLSKDFIdentifier: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension TLSKDFIdentifier {
     static let HKDF_SHA256 = TLSKDFIdentifier(rawValue: 0x0001, outputLength: 32)
     static let HKDF_SHA384 = TLSKDFIdentifier(rawValue: 0x0002, outputLength: 48)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 protocol PSKProtocol {
     var identity: ByteBuffer { get }
     var key: SymmetricKey { get }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum PSK: Equatable {
     case imported(ImportedPSK)
     case rawEPSK(RawEPSK)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct GeneralEPSK: Equatable, PSKProtocol {
     let innerPSK: PSK
 
@@ -153,7 +153,7 @@ struct GeneralEPSK: Equatable, PSKProtocol {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ImportedPSK: Equatable, PSKProtocol {
     let importedIdentity: ImportedIdentity
     let ipskx: SymmetricKey
@@ -162,14 +162,14 @@ struct ImportedPSK: Equatable, PSKProtocol {
     var key: SymmetricKey { ipskx }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct RawEPSK: Equatable, PSKProtocol {
     let identity: ByteBuffer
     let epsk: SymmetricKey
     var key: SymmetricKey { epsk }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ImportedIdentity: Hashable {
     let externalIdentity: ByteBuffer
     let context: ByteBuffer?
@@ -226,7 +226,7 @@ struct ImportedIdentity: Hashable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     mutating func writeUInt16LengthPrefixedImmutableBuffer(_ byteBuffer: ByteBuffer) {
         self.writeInteger(UInt16(byteBuffer.readableBytes))

--- a/Sources/Handshake/HandshakeState.swift
+++ b/Sources/Handshake/HandshakeState.swift
@@ -33,7 +33,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeState")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum HandshakeState {
 
     /// Ready, but the handshake has not yet started
@@ -336,7 +336,7 @@ enum HandshakeState {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeState {
     struct IdleState {
         var configuration: HandshakeStateMachine.Configuration
@@ -1341,7 +1341,7 @@ extension HandshakeState {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeState {
     var logDescription: String {
         switch self {

--- a/Sources/Handshake/HandshakeStateMachine.swift
+++ b/Sources/Handshake/HandshakeStateMachine.swift
@@ -33,7 +33,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeStateMachine")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct HandshakeStateMachine {
     private var parser = HandshakeMessageParser()
     private var serializer = TLSMessageSerializer()
@@ -609,7 +609,7 @@ struct HandshakeStateMachine {
 }
 
 // MARK: - Parsing
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeStateMachine {
     private mutating func handleReadServerHello(incomingBytes: inout InputBuffer) throws(TLSError) -> ProcessStep<PartialHandshakeResult> {
         logger.debug("client expecting server hello")
@@ -806,7 +806,7 @@ extension HandshakeStateMachine {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeStateMachine {
     /// This is `Optional<T>` with clearer names.
     fileprivate enum ProcessStep<ResultType> {
@@ -823,7 +823,7 @@ extension Collection where Element: Equatable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum TLSHandshakeStateMachine {
     case client(HandshakeStateMachine)
 #if !SWIFTTLS_CLIENT_ONLY
@@ -831,7 +831,7 @@ enum TLSHandshakeStateMachine {
 #endif
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension TLSHandshakeStateMachine {
     var isServer : Bool {
         switch self {

--- a/Sources/Handshake/HandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/HandshakeStateMachineConfiguration.swift
@@ -34,7 +34,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.HandshakeStateMa
 #endif
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public enum SwiftTLSPrivateKey {
     case p256(P256.Signing.PrivateKey)
 #if !SWIFTTLS_EMBEDDED && canImport(Darwin)
@@ -43,7 +43,7 @@ public enum SwiftTLSPrivateKey {
     case opaqueReference(SwiftTLSOpaqueReferenceKey)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeStateMachine {
     enum AuthenticationMethod {
         case noAuthAvailable

--- a/Sources/Handshake/Messages/CertificateMessage.swift
+++ b/Sources/Handshake/Messages/CertificateMessage.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct CertificateMessage {
     var certificateRequestContext: ByteBuffer
 
@@ -24,10 +24,10 @@ struct CertificateMessage {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateMessage: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateMessage {
     struct CertificateEntry {
         var opaqueCertificateData: ByteBuffer
@@ -42,10 +42,10 @@ extension CertificateMessage {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateMessage.CertificateEntry: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateMessage: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .certificate
@@ -86,7 +86,7 @@ extension CertificateMessage: HandshakeMessageProtocol {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readCertificateEntry() throws(TLSError) -> CertificateMessage.CertificateEntry? {
         guard let certificateData = try self.readVariableLengthVectorUInt24({ buffer in
@@ -103,7 +103,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeCertificateEntry(_ entry: CertificateMessage.CertificateEntry) -> Int {

--- a/Sources/Handshake/Messages/CertificateRequest.swift
+++ b/Sources/Handshake/Messages/CertificateRequest.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct CertificateRequest {
     var certificateRequestContext: ByteBuffer
 
@@ -24,10 +24,10 @@ struct CertificateRequest {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateRequest: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateRequest: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .certificateRequest

--- a/Sources/Handshake/Messages/CertificateVerify.swift
+++ b/Sources/Handshake/Messages/CertificateVerify.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct CertificateVerify {
     var algorithm: SignatureScheme
 
@@ -24,10 +24,10 @@ struct CertificateVerify {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateVerify: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateVerify: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .certificateVerify

--- a/Sources/Handshake/Messages/ClientHello.swift
+++ b/Sources/Handshake/Messages/ClientHello.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ClientHello {
     var legacyVersion: ProtocolVersion
     var random: Random
@@ -43,7 +43,7 @@ struct ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello {
     var serverCertificateTypes: [CertificateType] {
         for ext in self.extensions {
@@ -68,7 +68,7 @@ extension ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello {
     var signatureAlgorithms: [UInt16] {
         for ext in self.extensions {
@@ -80,7 +80,7 @@ extension ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello {
     var serverName: String? {
         for ext in self.extensions {
@@ -99,7 +99,7 @@ extension ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello {
     var alpns: [String] {
         for ext in self.extensions {
@@ -116,10 +116,10 @@ extension ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .clientHello

--- a/Sources/Handshake/Messages/EncryptedExtensions.swift
+++ b/Sources/Handshake/Messages/EncryptedExtensions.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct EncryptedExtensions {
     // TODO: enforcement on this value, only allow well-formed EncryptedExtensions.
     var extensions: Array<Extension>
@@ -22,10 +22,10 @@ struct EncryptedExtensions {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension EncryptedExtensions: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension EncryptedExtensions: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .encryptedExtensions

--- a/Sources/Handshake/Messages/FinishedMessage.swift
+++ b/Sources/Handshake/Messages/FinishedMessage.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct FinishedMessage {
     var verifyData: ByteBuffer
 
@@ -21,10 +21,10 @@ struct FinishedMessage {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension FinishedMessage: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension FinishedMessage: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .finished

--- a/Sources/Handshake/Messages/HandshakeMessage.swift
+++ b/Sources/Handshake/Messages/HandshakeMessage.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum HandshakeMessage: Hashable {
     case clientHello(ClientHello)
     case serverHello(ServerHello)

--- a/Sources/Handshake/Messages/HandshakeMessageProtocol.swift
+++ b/Sources/Handshake/Messages/HandshakeMessageProtocol.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A protocol adopted by all handshake messages.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 protocol HandshakeMessageProtocol {
     static var handshakeType: HandshakeType { get }
 
@@ -23,7 +23,7 @@ protocol HandshakeMessageProtocol {
     init(bytes: inout InputBuffer) throws(TLSError)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeHandshakeMessage<Message: HandshakeMessageProtocol>(_ message: Message) -> Int {

--- a/Sources/Handshake/Messages/NewSessonTicket.swift
+++ b/Sources/Handshake/Messages/NewSessonTicket.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct NewSessionTicket {
     var ticketLifetime: UInt32
     var ticketAgeAdd: UInt32
@@ -33,10 +33,10 @@ struct NewSessionTicket {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension NewSessionTicket: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension NewSessionTicket: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .newSessionTicket

--- a/Sources/Handshake/Messages/ServerHello.swift
+++ b/Sources/Handshake/Messages/ServerHello.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ServerHello {
     var legacyVersion: ProtocolVersion
     var random: Random
@@ -22,7 +22,7 @@ struct ServerHello {
     var extensions: Array<Extension>
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHello {
     var isHelloRetryRequest: Bool {
         return self.random == .helloRetryRequest
@@ -39,10 +39,10 @@ extension ServerHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHello: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHello: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
         .serverHello

--- a/Sources/Handshake/PartialHandshakeResult.swift
+++ b/Sources/Handshake/PartialHandshakeResult.swift
@@ -21,7 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct PartialHandshakeResult {
     var handshakeBytesToSend: ByteBuffer?
 

--- a/Sources/Handshake/PeerCertificateBundle.swift
+++ b/Sources/Handshake/PeerCertificateBundle.swift
@@ -38,7 +38,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.PeerCertificateB
 ///
 /// Depending on negotiated extensions, the bundle holds either X.509 certificates or raw
 /// public keys; a single bundle uses exactly one of these representations.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct PeerCertificateBundle {
     fileprivate var bundle: Bundle
 
@@ -203,7 +203,7 @@ struct PeerCertificateBundle {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PeerCertificateBundle {
     /// The kinds of certificate bundle this package supports.
     fileprivate enum Bundle {
@@ -212,7 +212,7 @@ extension PeerCertificateBundle {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PeerCertificateBundle {
     /// Whether this package supports unverified X.509.
     ///
@@ -254,10 +254,10 @@ extension PeerCertificateBundle {
     }()
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PeerCertificateBundle: Equatable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PeerCertificateBundle.Bundle: Equatable {
     static func ==(lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
@@ -271,7 +271,7 @@ extension PeerCertificateBundle.Bundle: Equatable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     mutating func writePeerCertificateBundle(_ bundle: PeerCertificateBundle) {
         switch bundle.bundle {
@@ -289,7 +289,7 @@ extension ByteBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readPeerCertificateBundle() throws(TLSError) -> PeerCertificateBundle? {
         guard let discriminator = self.readInteger(as: UInt8.self) else {

--- a/Sources/Handshake/ServerHandshakeState.swift
+++ b/Sources/Handshake/ServerHandshakeState.swift
@@ -35,7 +35,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeState")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum ServerHandshakeState {
     /// Ready, but the handshake has not yet started
     case idle(IdleState)
@@ -263,7 +263,7 @@ enum ServerHandshakeState {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHandshakeState {
     struct IdleState {
         var configuration: ServerHandshakeStateMachine.Configuration
@@ -1578,7 +1578,7 @@ extension ServerHandshakeState {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHandshakeState: CustomStringConvertible {
     var description: String {
         switch self {

--- a/Sources/Handshake/ServerHandshakeStateMachine.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachine.swift
@@ -36,7 +36,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeStateMachine")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct SwiftOfferedEPSK {
     let external_identity: Data
     let context: Data?
@@ -46,12 +46,12 @@ struct SwiftOfferedEPSK {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 typealias externalPSKCompletionCallback = (Int, EPSK?) -> Void
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 typealias externalPSKSelectionCallback = ([SwiftOfferedEPSK], @escaping externalPSKCompletionCallback) -> Void
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct ServerHandshakeStateMachine {
     private var parser = HandshakeMessageParser()
     private var serializer = TLSMessageSerializer()
@@ -474,7 +474,7 @@ struct ServerHandshakeStateMachine {
 
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHandshakeStateMachine {
     private mutating func handleReadClientHello(incomingBytes: inout InputBuffer) throws(TLSError) -> StepResult {
         logger.debug("server expecting client hello")
@@ -896,7 +896,7 @@ extension ServerHandshakeStateMachine {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHandshakeStateMachine {
     fileprivate enum StepResult {
         case partialResult(PartialHandshakeResult)

--- a/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
@@ -36,7 +36,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeStateMachineConfiguration")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ServerHandshakeStateMachine {
     enum AuthenticationMethod {
         case noAuthAvailable

--- a/Sources/Handshake/SessionTicket.swift
+++ b/Sources/Handshake/SessionTicket.swift
@@ -39,7 +39,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.SessionTicket")
 /// ticket age information, and details about the underlying handshake so that resumption can be validated.
 ///
 /// Critically, you can serialize and deserialize session tickets.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct SessionTicket {
     var issued: Date
 
@@ -218,16 +218,16 @@ struct SessionTicket {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension SessionTicket {
     /// The maximum cache lifetime allowed by RFC 8446.
     static fileprivate let maxLifetime = UInt32(604800)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension SessionTicket: Equatable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     mutating func writeLengthPrefixedString(_ string: String) {
         self.writeLengthPrefixedBytes(string.utf8)

--- a/Sources/HandshakeMessageParser.swift
+++ b/Sources/HandshakeMessageParser.swift
@@ -24,7 +24,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeMessageParser")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct HandshakeMessageParser {
     private var bufferedBytes: ByteBuffer?
     var readClientHello: Bool = false
@@ -184,7 +184,7 @@ struct HandshakeMessageParser {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension HandshakeMessageParser {
     struct ParseResult {
         var messageBytes: ByteBuffer

--- a/Sources/InputBuffer.swift
+++ b/Sources/InputBuffer.swift
@@ -19,7 +19,7 @@
 /// a client, such as incoming network data. It is non-copyable to ensure that
 /// it is always clear which code is actively reading the data, preventing
 /// mistakes where the same data is processed multiple times unnecessarily.
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct InputBuffer: ~Escapable, ~Copyable {
     /// Reference to the underlying storage that we're reading from.
     private let storage: RawSpan
@@ -46,7 +46,7 @@ struct InputBuffer: ~Escapable, ~Copyable {
 }
 
 // MARK: Reading
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     /// Reads the given number of bytes from the input buffer.
     ///
@@ -214,7 +214,7 @@ extension InputBuffer {
 }
 
 // MARK: Tentative reading
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     /// Execute the given body to allow it to read from this split
     /// input buffer (provided as an argument). If the body returns
@@ -240,7 +240,7 @@ extension InputBuffer {
 }
 
 // MARK: Seeking
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     /// Seek to a specific position.
     mutating func seek(to position: Int) {
@@ -250,7 +250,7 @@ extension InputBuffer {
 }
 
 // MARK: Copying out data
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     /// Copies the bytes from the buffer into the given raw output span.
     ///

--- a/Sources/KeyExchange.swift
+++ b/Sources/KeyExchange.swift
@@ -25,7 +25,7 @@ typealias SymmetricKey = CryptoKit.SymmetricKey
 typealias SymmetricKey = Crypto.SymmetricKey
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 protocol EphemeralPrivateKey {
     var namedGroup: NamedGroup { get }
     var publicKeyData: Data { get }
@@ -33,7 +33,7 @@ protocol EphemeralPrivateKey {
     func decap(ciphertextData: Data) throws(TLSError) -> SymmetricKey
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 enum GeneratedEphemeralPrivateKey: EphemeralPrivateKey {
     var namedGroup: NamedGroup {
         get {
@@ -88,7 +88,7 @@ enum GeneratedEphemeralPrivateKey: EphemeralPrivateKey {
     case X25519MLKEM768(X25519MLKEM768EphemeralKey)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct Curve25519EphemeralKey: EphemeralPrivateKey {
     var privateKey: Curve25519.KeyAgreement.PrivateKey
 
@@ -120,7 +120,7 @@ struct Curve25519EphemeralKey: EphemeralPrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct P384EphemeralKey: EphemeralPrivateKey {
     typealias T = P384.KeyAgreement.PrivateKey
     var privateKey: P384.KeyAgreement.PrivateKey
@@ -153,7 +153,7 @@ struct P384EphemeralKey: EphemeralPrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
     var privateKeyA: Curve25519.KeyAgreement.PrivateKey
     var privateKeyB: MLKEM768.PrivateKey
@@ -221,7 +221,7 @@ struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 func generateEphemeralKeyForNamedGroup(_ group: NamedGroup) -> GeneratedEphemeralPrivateKey? {
     switch group {
     case .secp384:
@@ -238,7 +238,7 @@ func generateEphemeralKeyForNamedGroup(_ group: NamedGroup) -> GeneratedEphemera
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension SymmetricKey {
     init(_copying bytes: RawSpan) {
         self = bytes.withUnsafeBytes { buffer in

--- a/Sources/Protocol Atoms/Alert.swift
+++ b/Sources/Protocol Atoms/Alert.swift
@@ -155,7 +155,7 @@ extension Alert: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readAlert() -> Alert? {
         let level = self.readInteger(as: UInt8.self)
@@ -167,7 +167,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeAlert(_ alert: Alert) -> Int {

--- a/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
+++ b/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
@@ -18,7 +18,7 @@ import Foundation
 
 typealias ApplicationLayerProtocol = String
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readApplicationLayerProtocol() -> ApplicationLayerProtocol? {
         guard let length = self.readInteger(as: UInt8.self) else {
@@ -34,7 +34,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeApplicationLayerProtocol(_ appProtocol: ApplicationLayerProtocol) -> Int {

--- a/Sources/Protocol Atoms/CertificateType.swift
+++ b/Sources/Protocol Atoms/CertificateType.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct CertificateType: RawRepresentable, Sendable {
     public var rawValue: UInt8
 
@@ -22,16 +22,16 @@ public struct CertificateType: RawRepresentable, Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateType {
     public static let x509 = CertificateType(rawValue: 0)
     public static let rawPublicKey = CertificateType(rawValue: 2)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateType: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension CertificateType: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -45,14 +45,14 @@ extension CertificateType: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readCertificateType() -> CertificateType? {
         return self.readInteger().map { CertificateType(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeCertificateType(_ type: CertificateType) -> Int {

--- a/Sources/Protocol Atoms/CipherSuite.swift
+++ b/Sources/Protocol Atoms/CipherSuite.swift
@@ -43,14 +43,14 @@ extension CipherSuite: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readCipherSuite() -> CipherSuite? {
         return self.readInteger().map { CipherSuite(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeCipherSuite(_ cipherSuite: CipherSuite) -> Int {

--- a/Sources/Protocol Atoms/ContentType.swift
+++ b/Sources/Protocol Atoms/ContentType.swift
@@ -49,14 +49,14 @@ extension ContentType: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readContentType() -> ContentType? {
         return self.readInteger().map { ContentType(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeContentType(_ type: ContentType) -> Int {

--- a/Sources/Protocol Atoms/HandshakeType.swift
+++ b/Sources/Protocol Atoms/HandshakeType.swift
@@ -67,14 +67,14 @@ extension HandshakeType: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readHandshakeType() -> HandshakeType? {
         return self.readInteger().map { HandshakeType(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeHandshakeType(_ type: HandshakeType) -> Int {

--- a/Sources/Protocol Atoms/LegacySessionID.swift
+++ b/Sources/Protocol Atoms/LegacySessionID.swift
@@ -24,7 +24,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.Handshake")
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct LegacySessionID {
     fileprivate var bytes: (UInt64, UInt64, UInt64, UInt64)
     fileprivate var length: Int
@@ -58,7 +58,7 @@ struct LegacySessionID {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension LegacySessionID: Hashable {
     static func ==(lhs: LegacySessionID, rhs: LegacySessionID) -> Bool {
         // Right now this can just check every byte unconditionally because we zero-initialize the other bytes.
@@ -75,7 +75,7 @@ extension LegacySessionID: Hashable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readLegacySessionID() throws(TLSError) -> LegacySessionID? {
         return try self.readVariableLengthVector(lengthFieldType: UInt8.self) { buffer throws(TLSError) in
@@ -91,7 +91,7 @@ extension InputBuffer {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeLegacySessionID(_ sessionID: LegacySessionID) -> Int {

--- a/Sources/Protocol Atoms/NamedGroup.swift
+++ b/Sources/Protocol Atoms/NamedGroup.swift
@@ -63,14 +63,14 @@ extension NamedGroup: CustomStringConvertible {
 
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readNamedGroup() -> NamedGroup? {
         return self.readInteger().map { NamedGroup(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeNamedGroup(_ namedGroup: NamedGroup) -> Int {

--- a/Sources/Protocol Atoms/ProtocolVersion.swift
+++ b/Sources/Protocol Atoms/ProtocolVersion.swift
@@ -51,14 +51,14 @@ extension ProtocolVersion: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readProtocolVersion() -> ProtocolVersion? {
         return self.readInteger(as: UInt16.self).map { ProtocolVersion(major: UInt8(truncatingIfNeeded: $0 >> 8) , minor: UInt8(truncatingIfNeeded: $0)) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeProtocolVersion(_ protocolVersion: ProtocolVersion) -> Int {

--- a/Sources/Protocol Atoms/Random.swift
+++ b/Sources/Protocol Atoms/Random.swift
@@ -49,14 +49,14 @@ extension Random: Hashable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readRandom() -> Random? {
         self.read(as: Random.self)
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeRandom(_ random: Random) -> Int {

--- a/Sources/Protocol Atoms/SignatureScheme.swift
+++ b/Sources/Protocol Atoms/SignatureScheme.swift
@@ -45,14 +45,14 @@ extension SignatureScheme: CustomStringConvertible {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension InputBuffer {
     mutating func readSignatureScheme() -> SignatureScheme? {
         return self.readInteger().map { SignatureScheme(rawValue: $0) }
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     @discardableResult
     mutating func writeSignatureScheme(_ type: SignatureScheme) -> Int {

--- a/Sources/SwiftTLSProtocol.swift
+++ b/Sources/SwiftTLSProtocol.swift
@@ -33,7 +33,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.SwiftTLSProtocol
 #endif
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public enum SwiftTLSError: Error, Equatable {
     case unsupportedOptions
     case invalidServerPrivateKey
@@ -42,7 +42,7 @@ public enum SwiftTLSError: Error, Equatable {
 }
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public struct SwiftTLSOptions {
     @frozen public enum EncryptionLevel: CustomDebugStringConvertible {
         case initial
@@ -150,7 +150,7 @@ public struct SwiftTLSOptions {
 
 // MARK: Common helper functions
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate extension CipherSuite {
     static func convertArray(_ input: [SwiftTLSOptions.CipherSuite]?) -> [CipherSuite]? {
         guard let input else { return nil }
@@ -165,7 +165,7 @@ fileprivate extension CipherSuite {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate func epskFromSwiftTLSOptions(_ options: SwiftTLSOptions) throws(SwiftTLSError) -> EPSK? {
     var epsk: EPSK? = nil
     if let externalPSK = options.externalPSK {
@@ -184,7 +184,7 @@ fileprivate func epskFromSwiftTLSOptions(_ options: SwiftTLSOptions) throws(Swif
     return epsk
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate func clientStateMachineFromTLSOptions(options: SwiftTLSOptions, forQUIC: Bool = true, latestError: inout LatestError?) throws(SwiftTLSError) -> HandshakeStateMachine {
     guard let applicationProtocols = options.applicationProtocols else {
         logger.error("Cannot start the handshake, missing application protocol")
@@ -289,7 +289,7 @@ fileprivate func clientStateMachineFromTLSOptions(options: SwiftTLSOptions, forQ
 
 #if !SWIFTTLS_CLIENT_ONLY
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate func serverStateMachineFromTLSOptions(options: SwiftTLSOptions, forQUIC: Bool = true) throws(SwiftTLSError) -> ServerHandshakeStateMachine {
     var keys: [P256.Signing.PublicKey]? = nil
     if let p256Keys = options.trustedRawPublicKeyP256PublicKeys {
@@ -358,13 +358,13 @@ fileprivate func serverStateMachineFromTLSOptions(options: SwiftTLSOptions, forQ
 
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate enum LatestError {
     case tlsError(TLSError)
     case cryptoKitMetaError(CryptoKitMetaError)
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 fileprivate func errorCodeFromLatestError(_ latestError: LatestError?) -> Int32 {
     guard let latestError = latestError else {
         #if canImport(CryptoKit) && !SWIFTTLS_EMBEDDED && !SWIFTTLS_EXCLAVEKIT && !SWIFTTLS_DRIVERKIT
@@ -423,7 +423,7 @@ fileprivate func errorCodeFromLatestError(_ latestError: LatestError?) -> Int32 
 // MARK: QUIC Handshakers
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 public class SwiftTLSHandshaker {
     public var receivedSessionTickets = [[UInt8]]()
 
@@ -530,7 +530,7 @@ public class SwiftTLSHandshaker {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class SwiftTLSClientHandshaker: SwiftTLSHandshaker {
     var stateMachine: HandshakeStateMachine?
 
@@ -654,7 +654,7 @@ class SwiftTLSClientHandshaker: SwiftTLSHandshaker {
 
 #if !SWIFTTLS_CLIENT_ONLY
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class SwiftTLSServerHandshaker: SwiftTLSHandshaker {
     var stateMachine: ServerHandshakeStateMachine?
     var clientAppSecret: SymmetricKey? = nil

--- a/Sources/TLSMessageSerializer.swift
+++ b/Sources/TLSMessageSerializer.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct TLSMessageSerializer {
     init() { }
 

--- a/Tests/SwiftTLSTests/ExtensionParsingTests.swift
+++ b/Tests/SwiftTLSTests/ExtensionParsingTests.swift
@@ -23,7 +23,7 @@ import CryptoKit
 #endif
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class ExtensionParsingTests: XCTestCase {
     /// Handy-dandy temporary key
     let key = P384.KeyAgreement.PrivateKey()
@@ -1247,7 +1247,7 @@ class ExtensionParsingTests: XCTestCase {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     mutating func readExtension(messageType: HandshakeType, helloRetryRequest: Bool) throws(TLSError) -> Extension? {
         try withInputBuffer { inputBuffer throws(TLSError) in

--- a/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
+++ b/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
@@ -22,7 +22,7 @@ import CryptoKit
 @testable import SwiftTLS
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class ExternalPreSharedKeyTests: XCTestCase {
     func testPSKImporterInterface() throws {
         let externalIdentity = ByteBuffer("test psk identity")

--- a/Tests/SwiftTLSTests/HandshakeStateMachineCallbackTests.swift
+++ b/Tests/SwiftTLSTests/HandshakeStateMachineCallbackTests.swift
@@ -29,7 +29,7 @@ import CryptoKit
 import Security
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 final class ClientCallbackFixtures: Sendable {
     let serverSigningKey: P256.Signing.PrivateKey
     let dummySignatureAlgorithm: UInt16
@@ -153,7 +153,7 @@ final class ClientCallbackFixtures: Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class HandshakeStateMachineCallbackTests: XCTestCase {
 
     var serverPrivateKey = P384EphemeralKey()

--- a/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
@@ -23,7 +23,7 @@ import CryptoKit
 #endif
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class HandshakeStateMachineTests: XCTestCase {
 
     var serverPrivateKey = P384EphemeralKey()
@@ -2158,7 +2158,7 @@ class HandshakeStateMachineTests: XCTestCase {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ClientHello {
 
     var clientKeyShare: Extension.KeyShare.KeyShareEntry {
@@ -2242,7 +2242,7 @@ extension ClientHello {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension Optional where Wrapped == PartialHandshakeResult {
     enum EncryptionLevelType {
         case earlyData
@@ -2297,7 +2297,7 @@ func assertNewEncryptionLevel(_ level: EncryptionLevelType, _ readOrWrite: ReadO
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension PartialHandshakeResult {
     func assertNewEncryptionLevel(_ level: Optional<PartialHandshakeResult>.EncryptionLevelType, _ readOrWrite: Optional<PartialHandshakeResult>.ReadOrWrite, file: StaticString = #filePath, line: UInt = #line) {
         Optional(self).assertNewEncryptionLevel(level, readOrWrite, file: file, line: line)

--- a/Tests/SwiftTLSTests/InputBufferTests.swift
+++ b/Tests/SwiftTLSTests/InputBufferTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import SwiftTLS
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class InputBufferTests: XCTestCase {
     // MARK: - Basic properties
 

--- a/Tests/SwiftTLSTests/KeyScheduleTests.swift
+++ b/Tests/SwiftTLSTests/KeyScheduleTests.swift
@@ -29,7 +29,7 @@ import CryptoKit
 /// This does not validate the underlying HKDF implementation because that's owned by CryptoKit.
 ///
 /// These tests use ECDHE keys that are not necessarily supported in the underlying implementation. This doesn't matter!
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 final class KeyScheduleTests: XCTestCase {
     func test1RTTExample() throws {
         /// This will run through an example flow of a 1RTT setup using RFC 8448.
@@ -88,7 +88,7 @@ final class KeyScheduleTests: XCTestCase {
 }
 
 // MARK: Static data
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension KeyScheduleTests {
     static let oneRTTClientX25519Key = try! Curve25519.KeyAgreement.PrivateKey(
         rawRepresentation: [0x49, 0xaf, 0x42, 0xba, 0x7f, 0x79, 0x94, 0x85, 0x2d, 0x71, 0x3e, 0xf2,
@@ -534,7 +534,7 @@ extension KeyScheduleTests {
     )
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 struct FrozenInTimeClock: SwiftTLSClock {
     var time: Date
 

--- a/Tests/SwiftTLSTests/ProtocolAtomParsingTests.swift
+++ b/Tests/SwiftTLSTests/ProtocolAtomParsingTests.swift
@@ -18,7 +18,7 @@ import XCTest
 #endif
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class ProtocolAtomParsingTests: XCTestCase {
     var buffer: ByteBuffer!
 

--- a/Tests/SwiftTLSTests/RoundTripParserTests.swift
+++ b/Tests/SwiftTLSTests/RoundTripParserTests.swift
@@ -18,7 +18,7 @@ import XCTest
 #endif
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class RoundTripParserTests: XCTestCase {
     private func roundTripTest_oneShot(_ message: HandshakeMessage) throws {
         var buffer = ByteBuffer()
@@ -230,7 +230,7 @@ class RoundTripParserTests: XCTestCase {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 extension ByteBuffer {
     init(_ string: String) {
         self = ByteBuffer(data: Data(string.utf8))

--- a/Tests/SwiftTLSTests/ServerHandshakeStateMachineCallbackTests.swift
+++ b/Tests/SwiftTLSTests/ServerHandshakeStateMachineCallbackTests.swift
@@ -29,7 +29,7 @@ import CryptoKit
 import Security
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 final class ServerCallbackFixtures: Sendable {
     let serverSigningKey: P256.Signing.PrivateKey
     let serverSignatureAlgorithm: UInt16
@@ -261,7 +261,7 @@ final class ServerCallbackFixtures: Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class ServerHandshakeStateMachineCallbackTests: XCTestCase {
 
     var serverPrivateKey = P384EphemeralKey()

--- a/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
@@ -48,7 +48,7 @@ enum ErrorLocation {
     case readClientFinished
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class ServerHandshakeStateMachineTests: XCTestCase {
     override func setUp() {
         continueAfterFailure = false

--- a/Tests/SwiftTLSTests/SessionTicketTests.swift
+++ b/Tests/SwiftTLSTests/SessionTicketTests.swift
@@ -26,7 +26,7 @@ import CryptoKit
 #endif
 
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 final class SessionTicketTests: XCTestCase {
     // A helper function that lets us tweak one parameter at a time.
     private static func baselineNewSessionTicket(ticketLifetime: UInt32 = .max,

--- a/Tests/SwiftTLSTests/SwiftTLSProtocolTests.swift
+++ b/Tests/SwiftTLSTests/SwiftTLSProtocolTests.swift
@@ -22,7 +22,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class SwiftTLSProtocolTests: XCTestCase {
     var serverSigningKey = P256.Signing.PrivateKey()
     var clientSigningKey = P256.Signing.PrivateKey()

--- a/Tests/SwiftTLSTests/TestUtil.swift
+++ b/Tests/SwiftTLSTests/TestUtil.swift
@@ -25,7 +25,7 @@ import CryptoKit
 import Foundation
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 var goodClientHello: ClientHello {
   let ephemeralKey = P384EphemeralKey()
   return ClientHello(
@@ -51,7 +51,7 @@ var goodClientHello: ClientHello {
   )
 }
 
-@available(SwiftTLS 0.1.0, *)
+@available(anyAppleOS 26, *)
 class TestConfigurationGenerator {
     let serverSigningKey = P256.Signing.PrivateKey()
     let clientSigningKey =  P256.Signing.PrivateKey()


### PR DESCRIPTION
Adopt `anyAppleOS` availability and drop the custom availability macro

Replace every `@available(SwiftTLS 0.1.0, *)` annotation across `Sources/` and `Tests/` with the equivalent `@available(anyAppleOS 26, *)`.

Drop the package-level macro plumbing this enables: the `AvailabilityMacro=SwiftTLS 0.1.0:macOS 26, ...` `enableExperimentalFeature` setting, the `_OSAvailability` / `_Availability` helpers, and the per-target `availabilityMacros + ` prefix on `swiftSettings`. Adopters no longer need to know the macro name to read the source.

Future-gated declarations can use `@available(anyAppleOS 10000, *)` directly instead of going through the `_OSAvailability.future` case.

This PR also includes as a separate commit the relaxation of some overly-strict availability annotations.