### PR TITLE
Finesse `@available` guards: document rationale and relax over-annota…

### DIFF
--- a/Sources/ArraySpanUtilities.swift
+++ b/Sources/ArraySpanUtilities.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Array where Element == UInt8 {
     /// Creates an array by copying the bytes of the given raw span.
@@ -27,6 +28,7 @@ extension Array where Element == UInt8 {
     }
 }
 
+// Availability due to `Swift`'s `InlineArray`
 @available(SwiftTLS 0.1.0, *)
 extension InlineArray where Element == UInt8 {
     /// Creates an inline array by copying the bytes of the given raw span.
@@ -42,6 +44,7 @@ extension InlineArray where Element == UInt8 {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Hasher {
     mutating func combine(bytes: RawSpan) {
@@ -51,6 +54,7 @@ extension Hasher {
     }
 }
 
+// Availability due to `Swift`'s `InlineArray`
 @available(SwiftTLS 0.1.0, *)
 extension InlineArray where Element: Equatable {
     static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -64,6 +68,7 @@ extension InlineArray where Element: Equatable {
     }
 }
 
+// Availability due to `Swift`'s `OutputRawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension OutputRawSpan {
     /// Appends the contents of the given raw span to this output span.
@@ -74,6 +79,7 @@ extension OutputRawSpan {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension RawSpan {
     subscript(index: Int) -> UInt8 {

--- a/Sources/ByteBuffer.swift
+++ b/Sources/ByteBuffer.swift
@@ -28,6 +28,7 @@ extension Data {
 ///
 /// This is not a truly hardened version of NIO's ByteBuffer. It lacks some flexibility, but it's
 /// good enough for what we need.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ByteBuffer {
     private var backingData: Data
@@ -218,6 +219,7 @@ struct ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult
@@ -283,6 +285,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer: Hashable {
     static func ==(lhs: ByteBuffer, rhs: ByteBuffer) -> Bool {
@@ -294,6 +297,7 @@ extension ByteBuffer: Hashable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     /// Execute the given `body` function with an input buffer that can access

--- a/Sources/Callbacks.swift
+++ b/Sources/Callbacks.swift
@@ -18,7 +18,6 @@ import Foundation
 
 // Result type for async computations applied to the handshaker.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct PendingAsyncResult: Sendable {
     enum AsyncResult {
         case certificate(CertificateResult)
@@ -43,7 +42,6 @@ public struct PendingAsyncResult: Sendable {
 
 // List of opaque certificate data.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct CertificateList: Sendable, Hashable {
     public var type: CertificateType
     public var entries: [Data]
@@ -56,13 +54,14 @@ public struct CertificateList: Sendable, Hashable {
 
 // Information offered by the client during the handshake.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct PeerOffer: Sendable, Hashable {
     public var certificateTypes: [CertificateType]
     public var signatureAlgorithms: [UInt16]
     public var serverName: String?
     public var alpns: [String]?
 
+    // Availability due to `RawSpan`
+    @available(SwiftTLS 0.1.0, *)
     init(clientHello: ClientHello) {
         self.certificateTypes = clientHello.serverCertificateTypes
         self.signatureAlgorithms = clientHello.signatureAlgorithms
@@ -74,7 +73,6 @@ public struct PeerOffer: Sendable, Hashable {
 // The result waiting indicates asynchronous work in the callback.
 // The reason given for an unavailable certificate will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public enum CertificateResult: Sendable, Hashable {
     case available(CertificateList)
     case unavailable(reason: String)
@@ -83,7 +81,6 @@ public enum CertificateResult: Sendable, Hashable {
 
 // Information passed into the callback.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct CertificateInfo: Sendable {
     public var peerOffer: PeerOffer
     public var deliverResult: (@Sendable (CertificateResult) -> Void)?
@@ -99,13 +96,11 @@ public struct CertificateInfo: Sendable {
 // Note: This callback must either return a result directly (available, unavailable)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public typealias CertificateCallback = @Sendable (CertificateInfo) -> CertificateResult
 
 // The result waiting indicates asynchronous work in the callback.
 // The reason given for an unavailable signature will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public enum SignatureResult: Sendable, Hashable {
     case available(signature: Data, algorithm: UInt16)
     case unavailable(reason: String)
@@ -114,7 +109,6 @@ public enum SignatureResult: Sendable, Hashable {
 
 // Information passed into the callback.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct SignatureInfo: Sendable {
     public var transcriptHash: Data
     public var peerOffer: PeerOffer
@@ -132,12 +126,10 @@ public struct SignatureInfo: Sendable {
 // Note: This callback must either return a result directly (available, unavailable)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public typealias SignatureCallback = @Sendable (SignatureInfo) -> SignatureResult
 
 // Bundles the callbacks for the server to customize the certificate messages.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct AsyncAuthenticator: Sendable {
     public var supportedCertificateTypes: [CertificateType]
     public var getCertificateChain: CertificateCallback
@@ -157,7 +149,6 @@ public struct AsyncAuthenticator: Sendable {
 // Waiting indicates ongoing asynchronous work in the callback.
 // The reason given for an invalid verification will be logged.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public enum VerificationResult: Sendable, Hashable {
     case valid
     case invalid(reason: String)
@@ -166,7 +157,6 @@ public enum VerificationResult: Sendable, Hashable {
 
 // Information to verify the certificates and signature presented by the peer.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct VerificationInfo: Sendable {
     public var certificates: CertificateList
     public var signatureAlgorithm: UInt16
@@ -191,11 +181,9 @@ public struct VerificationInfo: Sendable {
 // Note: This callback must either return a result directly (valid, invalid)
 //  or return waiting and call `deliverResult` with the pending result.
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public typealias VerificationCallback = @Sendable (VerificationInfo) -> VerificationResult
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct AsyncVerifier: Sendable {
     public var availableCertificateTypes: [CertificateType]
     public var verifyHandshake: VerificationCallback

--- a/Sources/Cryptography/HKDF+Label.swift
+++ b/Sources/Cryptography/HKDF+Label.swift
@@ -21,6 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
+// Availability due to `CryptoKit`'s `HKDF`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension HKDF {
     static func expandLabel<SecretBytes: ContiguousBytes, ContextBytes: ContiguousBytes>(secret: SecretBytes, label: String, context: ContextBytes, length: Int) -> SymmetricKey {

--- a/Sources/Cryptography/HashFunction+Helpers.swift
+++ b/Sources/Cryptography/HashFunction+Helpers.swift
@@ -21,6 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
+// Availability due to `CryptoKit`'s `HashFunction`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HashFunction {
     static var zeroHash: Self.Digest {
@@ -28,6 +29,7 @@ extension HashFunction {
     }
 }
 
+// Availability due to `CryptoKit`'s `HMAC`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HMAC {
     static func authenticationCode<Bytes: ContiguousBytes>(bytes: Bytes, using key: SymmetricKey) -> HashedAuthenticationCode<H> {

--- a/Sources/Cryptography/KeyScheduler.swift
+++ b/Sources/Cryptography/KeyScheduler.swift
@@ -22,6 +22,7 @@ import CryptoKit
 #endif
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "SessionKeyManager")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -34,6 +35,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.SessionKeyManage
 
 // Wrapper around SessionKeyManager that only exposes functions a client should
 // need to call to help avoid invalid transitions.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ClientSessionKeyManager<HF: HashFunction> {
     private var sessionKeyManager: SessionKeyManager<HF>
@@ -135,6 +137,7 @@ struct ClientSessionKeyManager<HF: HashFunction> {
 
 // Wrapper around SessionKeyManager that only exposes functions a server should
 // need to call to help avoid invalid transitions.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ServerSessionKeyManager<HF: HashFunction> {
     private var sessionKeyManager: SessionKeyManager<HF>
@@ -220,6 +223,7 @@ struct ServerSessionKeyManager<HF: HashFunction> {
 /// The TLS 1.3 key schedule builds out a ratchet of keys and secrets for various purposes.
 /// This object encapsulates the current state in the key schedule and provides access to the
 /// various secrets for the rest of the code to use.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 fileprivate struct SessionKeyManager<HF: HashFunction> {
 
@@ -523,6 +527,7 @@ fileprivate struct SessionKeyManager<HF: HashFunction> {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension SessionKeyManager {
     fileprivate enum State {
@@ -561,6 +566,7 @@ extension SessionKeyManager {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension SessionKeyManager.State {
     fileprivate struct EarlySecret {
@@ -1000,6 +1006,7 @@ extension SessionKeyManager.State {
     }
 }
 
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 fileprivate extension Logger {
     func logInvalidStateTransition(stateName: String, event: String) {

--- a/Sources/Cryptography/PrivateKey.swift
+++ b/Sources/Cryptography/PrivateKey.swift
@@ -24,7 +24,8 @@ import CryptoKit
 /// A generic wrapper over the supported private-key types.
 ///
 /// Loosely based on the implementation in Swift Certificates.
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 struct PrivateKey {
     var backing: BackingPrivateKey
 
@@ -94,10 +95,12 @@ struct PrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PrivateKey: Hashable {}
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PrivateKey: CustomStringConvertible {
     var description: String {
         switch self.backing {
@@ -115,13 +118,11 @@ extension PrivateKey: CustomStringConvertible {
 
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
 public typealias SwiftTLSSignatureScheme = UInt16
 
 /// A callback that accepts the bytes to sign and the negotiated TLS signature scheme,
 /// and returns the signature, or `nil` when signing fails.
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
 public typealias SwiftTLSRefKeySignCallback = (Data, SwiftTLSSignatureScheme) -> Data?
 
 /// The underlying key types supported by `SwiftTLSOpaqueReferenceKey`.
@@ -132,7 +133,8 @@ enum SwiftTLSOpaqueReferenceKeyType: Sendable {
 /// A generic private-key type that lets a caller produce signatures over data using any key
 /// the caller can access.
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 public struct SwiftTLSOpaqueReferenceKey {
     let publicKey: PublicKey
     let sign: SwiftTLSRefKeySignCallback
@@ -167,7 +169,8 @@ public struct SwiftTLSOpaqueReferenceKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PrivateKey {
     enum BackingPrivateKey: Hashable {
         case p256(P256.Signing.PrivateKey)

--- a/Sources/Cryptography/PublicKey.swift
+++ b/Sources/Cryptography/PublicKey.swift
@@ -24,6 +24,7 @@ import CryptoKit
 /// An opaque wrapper around the supported public-key types.
 ///
 /// Loosely based on Swift Certificates' `PublicKey`.
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 struct PublicKey {
 
@@ -40,6 +41,7 @@ struct PublicKey {
     }
 }
 
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey {
     var derRepresentation: Data {
@@ -47,13 +49,16 @@ extension PublicKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: Hashable {}
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: Sendable {}
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey: CustomStringConvertible {
     var description: String {
         switch self.backing {
@@ -63,6 +68,7 @@ extension PublicKey: CustomStringConvertible {
     }
 }
 
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 extension PublicKey {
     enum BackingPublicKey: Hashable, Sendable {

--- a/Sources/DataUtilities.swift
+++ b/Sources/DataUtilities.swift
@@ -16,6 +16,7 @@
 import Foundation
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Data {
     /// Creates a `Data` instance by copying the raw bytes from the given span.

--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -16,7 +16,6 @@
 typealias CryptoKitMetaError = any Error
 #endif
 
-@available(SwiftTLS 0.1.0, *)
 enum TLSError: Error, Equatable {
     case truncatedMessage
     case excessBytes
@@ -66,7 +65,6 @@ enum TLSError: Error, Equatable {
     case refKeySigningFailure
 }
 
-@available(SwiftTLS 0.1.0, *)
 extension TLSError {
     static func wrappingCryptoError<Return, E:Error>(_ block: () throws(E) -> Return) throws(TLSError) -> Return {
         do {

--- a/Sources/Extensions/Extension.swift
+++ b/Sources/Extensions/Extension.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum Extension {
     case serverName(ServerName)
@@ -63,9 +64,11 @@ enum Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readExtension(messageType: HandshakeType, helloRetryRequest: Bool) throws(TLSError) -> Extension? {
@@ -121,6 +124,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/ExtensionType.swift
+++ b/Sources/Extensions/ExtensionType.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(SwiftTLS 0.1.0, *)
 struct ExtensionType: RawRepresentable, Sendable {
     var rawValue: UInt16
 
@@ -21,7 +20,6 @@ struct ExtensionType: RawRepresentable, Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
 extension ExtensionType {
     static let serverName = ExtensionType(rawValue: 0)
 
@@ -89,6 +87,7 @@ extension ExtensionType: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readExtensionType() -> ExtensionType? {
@@ -96,6 +95,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+ALPN.swift
+++ b/Sources/Extensions/Extensions+ALPN.swift
@@ -16,6 +16,7 @@
 import Foundation
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum ApplicationLayerProtocolNegotiation {
@@ -24,9 +25,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.ApplicationLayerProtocolNegotiation: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult
@@ -47,6 +50,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readALPN(messageType: HandshakeType) throws(TLSError) -> Extension.ApplicationLayerProtocolNegotiation {

--- a/Sources/Extensions/Extensions+CertificateType.swift
+++ b/Sources/Extensions/Extensions+CertificateType.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum CertificateTypeExt {
@@ -20,9 +21,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.CertificateTypeExt: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult
@@ -41,6 +44,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readCertificateType(messageType: HandshakeType) throws(TLSError) -> Extension.CertificateTypeExt {

--- a/Sources/Extensions/Extensions+EarlyData.swift
+++ b/Sources/Extensions/Extensions+EarlyData.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     struct EarlyData {
@@ -20,9 +21,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.EarlyData: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult
@@ -35,6 +38,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readEarlyDataExtension(messageType: HandshakeType) throws(TLSError) -> Extension.EarlyData {

--- a/Sources/Extensions/Extensions+KeyShare.swift
+++ b/Sources/Extensions/Extensions+KeyShare.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum KeyShare {
@@ -21,9 +22,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.KeyShare: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.KeyShare {
     struct KeyShareEntry {
@@ -37,9 +40,11 @@ extension Extension.KeyShare {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.KeyShare.KeyShareEntry: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.KeyShare.KeyShareEntry: CustomStringConvertible {
     var description: String {
@@ -47,6 +52,7 @@ extension Extension.KeyShare.KeyShareEntry: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult
@@ -76,6 +82,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readKeyShareEntry() -> Extension.KeyShare.KeyShareEntry? {

--- a/Sources/Extensions/Extensions+PreSharedKey.swift
+++ b/Sources/Extensions/Extensions+PreSharedKey.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum PreSharedKey {
@@ -20,6 +21,7 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey {
     struct OfferedPSKs {
@@ -29,6 +31,7 @@ extension Extension.PreSharedKey {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey.OfferedPSKs {
     struct PSKIdentity {
@@ -38,6 +41,7 @@ extension Extension.PreSharedKey.OfferedPSKs {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey.OfferedPSKs {
     struct PSKBinderEntry {
@@ -45,18 +49,23 @@ extension Extension.PreSharedKey.OfferedPSKs {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey.OfferedPSKs: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey.OfferedPSKs.PSKIdentity: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKey.OfferedPSKs.PSKBinderEntry: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readPSKIdentity() throws(TLSError) -> Extension.PreSharedKey.OfferedPSKs.PSKIdentity? {
@@ -138,6 +147,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+PreSharedKeyKexModes.swift
+++ b/Sources/Extensions/Extensions+PreSharedKeyKexModes.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     struct PreSharedKeyKexModes {
@@ -19,6 +20,7 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKeyKexModes {
     struct Mode: RawRepresentable, Hashable {
@@ -33,9 +35,11 @@ extension Extension.PreSharedKeyKexModes {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.PreSharedKeyKexModes: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readPreSharedKeyKexModes(messageType: HandshakeType) throws(TLSError) -> Extension.PreSharedKeyKexModes {
@@ -60,6 +64,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+QUICTransportParameters.swift
+++ b/Sources/Extensions/Extensions+QUICTransportParameters.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     // For consistency with other implementations, we don't introspect this field at all.
@@ -20,9 +21,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.QUICTransportParameters: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readQUICTransportParameters(messageType: HandshakeType) throws(TLSError) -> Extension.QUICTransportParameters {
@@ -36,6 +39,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+ServerName.swift
+++ b/Sources/Extensions/Extensions+ServerName.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum ServerName {
@@ -21,6 +22,7 @@ extension Extension {
 
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.ServerName {
     struct Names {
@@ -30,12 +32,15 @@ extension Extension.ServerName {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.ServerName: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.ServerName.Names: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readServerName(messageType: HandshakeType) throws(TLSError) -> Extension.ServerName {
@@ -105,6 +110,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+SignatureAlgorithms.swift
+++ b/Sources/Extensions/Extensions+SignatureAlgorithms.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     struct SignatureAlgorithms {
@@ -23,9 +24,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.SignatureAlgorithms: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readSignatureAlgorithms(messageType: HandshakeType) throws(TLSError) -> Extension.SignatureAlgorithms {
@@ -54,6 +57,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+SupportedGroups.swift
+++ b/Sources/Extensions/Extensions+SupportedGroups.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     struct SupportedGroups {
@@ -23,9 +24,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.SupportedGroups: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readSupportedGroups(messageType: HandshakeType) throws(TLSError) -> Extension.SupportedGroups {
@@ -54,6 +57,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+SupportedVersions.swift
+++ b/Sources/Extensions/Extensions+SupportedVersions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum SupportedVersions {
@@ -20,9 +21,11 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.SupportedVersions: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readSupportedVersions(messageType: HandshakeType) throws(TLSError) -> Extension.SupportedVersions {
@@ -57,6 +60,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Extensions/Extensions+TicketRequest.swift
+++ b/Sources/Extensions/Extensions+TicketRequest.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension {
     enum TicketRequest {
@@ -20,10 +21,10 @@ extension Extension {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.TicketRequest: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
 struct ClientTicketRequest: Hashable, CustomStringConvertible {
     var newSessionCount: UInt8
     var resumptionCount: UInt8
@@ -38,6 +39,7 @@ struct ClientTicketRequest: Hashable, CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.TicketRequest {
     struct ServerTicketRequestHint {
@@ -49,9 +51,11 @@ extension Extension.TicketRequest {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.TicketRequest.ServerTicketRequestHint: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Extension.TicketRequest.ServerTicketRequestHint: CustomStringConvertible {
     var description: String {
@@ -59,6 +63,7 @@ extension Extension.TicketRequest.ServerTicketRequestHint: CustomStringConvertib
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readTicketRequestExtension(messageType: HandshakeType) throws(TLSError) -> Extension.TicketRequest {
@@ -80,6 +85,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Handshake/ExternalPreSharedKey.swift
+++ b/Sources/Handshake/ExternalPreSharedKey.swift
@@ -21,6 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct EPSK {
     let externalIdentity: ByteBuffer
@@ -61,7 +62,6 @@ struct EPSK {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
 struct TLSKDFIdentifier: Sendable {
     public let rawValue: UInt16
     public let outputLength: Int
@@ -83,27 +83,28 @@ struct TLSKDFIdentifier: Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
 extension TLSKDFIdentifier: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
 extension TLSKDFIdentifier {
     static let HKDF_SHA256 = TLSKDFIdentifier(rawValue: 0x0001, outputLength: 32)
     static let HKDF_SHA384 = TLSKDFIdentifier(rawValue: 0x0002, outputLength: 48)
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 protocol PSKProtocol {
     var identity: ByteBuffer { get }
     var key: SymmetricKey { get }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum PSK: Equatable {
     case imported(ImportedPSK)
     case rawEPSK(RawEPSK)
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct GeneralEPSK: Equatable, PSKProtocol {
     let innerPSK: PSK
@@ -153,6 +154,7 @@ struct GeneralEPSK: Equatable, PSKProtocol {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ImportedPSK: Equatable, PSKProtocol {
     let importedIdentity: ImportedIdentity
@@ -162,6 +164,7 @@ struct ImportedPSK: Equatable, PSKProtocol {
     var key: SymmetricKey { ipskx }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct RawEPSK: Equatable, PSKProtocol {
     let identity: ByteBuffer
@@ -169,6 +172,7 @@ struct RawEPSK: Equatable, PSKProtocol {
     var key: SymmetricKey { epsk }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ImportedIdentity: Hashable {
     let externalIdentity: ByteBuffer
@@ -226,6 +230,7 @@ struct ImportedIdentity: Hashable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     mutating func writeUInt16LengthPrefixedImmutableBuffer(_ byteBuffer: ByteBuffer) {

--- a/Sources/Handshake/HandshakeState.swift
+++ b/Sources/Handshake/HandshakeState.swift
@@ -23,6 +23,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "HandshakeState")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -33,6 +34,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeState")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum HandshakeState {
 
@@ -336,6 +338,7 @@ enum HandshakeState {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeState {
     struct IdleState {
@@ -1341,6 +1344,7 @@ extension HandshakeState {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeState {
     var logDescription: String {

--- a/Sources/Handshake/HandshakeStateMachine.swift
+++ b/Sources/Handshake/HandshakeStateMachine.swift
@@ -23,6 +23,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "HandshakeStateMachine")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -33,6 +34,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeStateMachine")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct HandshakeStateMachine {
     private var parser = HandshakeMessageParser()
@@ -609,6 +611,7 @@ struct HandshakeStateMachine {
 }
 
 // MARK: - Parsing
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeStateMachine {
     private mutating func handleReadServerHello(incomingBytes: inout InputBuffer) throws(TLSError) -> ProcessStep<PartialHandshakeResult> {
@@ -806,6 +809,7 @@ extension HandshakeStateMachine {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeStateMachine {
     /// This is `Optional<T>` with clearer names.
@@ -823,6 +827,7 @@ extension Collection where Element: Equatable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum TLSHandshakeStateMachine {
     case client(HandshakeStateMachine)
@@ -831,6 +836,7 @@ enum TLSHandshakeStateMachine {
 #endif
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension TLSHandshakeStateMachine {
     var isServer : Bool {

--- a/Sources/Handshake/HandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/HandshakeStateMachineConfiguration.swift
@@ -23,6 +23,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "HandshakeStateMachineConfiguration")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -34,7 +35,8 @@ private let logger = Logger(label: "com.apple.security.swifttls.HandshakeStateMa
 #endif
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P256.Signing.PublicKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 public enum SwiftTLSPrivateKey {
     case p256(P256.Signing.PrivateKey)
 #if !SWIFTTLS_EMBEDDED && canImport(Darwin)
@@ -43,6 +45,7 @@ public enum SwiftTLSPrivateKey {
     case opaqueReference(SwiftTLSOpaqueReferenceKey)
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeStateMachine {
     enum AuthenticationMethod {

--- a/Sources/Handshake/Messages/CertificateMessage.swift
+++ b/Sources/Handshake/Messages/CertificateMessage.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct CertificateMessage {
     var certificateRequestContext: ByteBuffer
@@ -24,9 +25,11 @@ struct CertificateMessage {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateMessage: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateMessage {
     struct CertificateEntry {
@@ -42,9 +45,11 @@ extension CertificateMessage {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateMessage.CertificateEntry: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateMessage: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {
@@ -86,6 +91,7 @@ extension CertificateMessage: HandshakeMessageProtocol {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readCertificateEntry() throws(TLSError) -> CertificateMessage.CertificateEntry? {
@@ -103,6 +109,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Handshake/Messages/CertificateRequest.swift
+++ b/Sources/Handshake/Messages/CertificateRequest.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct CertificateRequest {
     var certificateRequestContext: ByteBuffer
@@ -24,9 +25,11 @@ struct CertificateRequest {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateRequest: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateRequest: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/CertificateVerify.swift
+++ b/Sources/Handshake/Messages/CertificateVerify.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct CertificateVerify {
     var algorithm: SignatureScheme
@@ -24,9 +25,11 @@ struct CertificateVerify {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateVerify: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension CertificateVerify: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/ClientHello.swift
+++ b/Sources/Handshake/Messages/ClientHello.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ClientHello {
     var legacyVersion: ProtocolVersion
@@ -43,6 +44,7 @@ struct ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello {
     var serverCertificateTypes: [CertificateType] {
@@ -68,6 +70,7 @@ extension ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello {
     var signatureAlgorithms: [UInt16] {
@@ -80,6 +83,7 @@ extension ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello {
     var serverName: String? {
@@ -99,6 +103,7 @@ extension ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello {
     var alpns: [String] {
@@ -116,9 +121,11 @@ extension ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/EncryptedExtensions.swift
+++ b/Sources/Handshake/Messages/EncryptedExtensions.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct EncryptedExtensions {
     // TODO: enforcement on this value, only allow well-formed EncryptedExtensions.
@@ -22,9 +23,11 @@ struct EncryptedExtensions {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension EncryptedExtensions: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension EncryptedExtensions: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/FinishedMessage.swift
+++ b/Sources/Handshake/Messages/FinishedMessage.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct FinishedMessage {
     var verifyData: ByteBuffer
@@ -21,9 +22,11 @@ struct FinishedMessage {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension FinishedMessage: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension FinishedMessage: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/HandshakeMessage.swift
+++ b/Sources/Handshake/Messages/HandshakeMessage.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum HandshakeMessage: Hashable {
     case clientHello(ClientHello)

--- a/Sources/Handshake/Messages/HandshakeMessageProtocol.swift
+++ b/Sources/Handshake/Messages/HandshakeMessageProtocol.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A protocol adopted by all handshake messages.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 protocol HandshakeMessageProtocol {
     static var handshakeType: HandshakeType { get }
@@ -23,6 +24,7 @@ protocol HandshakeMessageProtocol {
     init(bytes: inout InputBuffer) throws(TLSError)
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Handshake/Messages/NewSessonTicket.swift
+++ b/Sources/Handshake/Messages/NewSessonTicket.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct NewSessionTicket {
     var ticketLifetime: UInt32
@@ -33,9 +34,11 @@ struct NewSessionTicket {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension NewSessionTicket: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension NewSessionTicket: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/Messages/ServerHello.swift
+++ b/Sources/Handshake/Messages/ServerHello.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ServerHello {
     var legacyVersion: ProtocolVersion
@@ -22,6 +23,7 @@ struct ServerHello {
     var extensions: Array<Extension>
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHello {
     var isHelloRetryRequest: Bool {
@@ -39,9 +41,11 @@ extension ServerHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHello: Hashable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHello: HandshakeMessageProtocol {
     static var handshakeType: HandshakeType {

--- a/Sources/Handshake/PartialHandshakeResult.swift
+++ b/Sources/Handshake/PartialHandshakeResult.swift
@@ -21,6 +21,7 @@ import CryptoKit
 @preconcurrency import Crypto
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct PartialHandshakeResult {
     var handshakeBytesToSend: ByteBuffer?
@@ -41,6 +42,7 @@ struct PartialHandshakeResult {
 ///
 /// Note that this excludes the "initial" level. That level is implicit: until you observe one
 /// of these values, the connection remains at the `initial` level.
+// Availability due to `CryptoKit`'s `SymmetricKey`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 enum EncryptionLevel {
     case earlyData(secret: SymmetricKey)

--- a/Sources/Handshake/PeerCertificateBundle.swift
+++ b/Sources/Handshake/PeerCertificateBundle.swift
@@ -23,6 +23,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "PeerCertificateBundle")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -38,6 +39,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.PeerCertificateB
 ///
 /// Depending on negotiated extensions, the bundle holds either X.509 certificates or raw
 /// public keys; a single bundle uses exactly one of these representations.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct PeerCertificateBundle {
     fileprivate var bundle: Bundle
@@ -203,6 +205,7 @@ struct PeerCertificateBundle {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension PeerCertificateBundle {
     /// The kinds of certificate bundle this package supports.
@@ -212,6 +215,7 @@ extension PeerCertificateBundle {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension PeerCertificateBundle {
     /// Whether this package supports unverified X.509.
@@ -254,9 +258,11 @@ extension PeerCertificateBundle {
     }()
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension PeerCertificateBundle: Equatable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension PeerCertificateBundle.Bundle: Equatable {
     static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -271,6 +277,7 @@ extension PeerCertificateBundle.Bundle: Equatable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     mutating func writePeerCertificateBundle(_ bundle: PeerCertificateBundle) {
@@ -289,6 +296,7 @@ extension ByteBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readPeerCertificateBundle() throws(TLSError) -> PeerCertificateBundle? {

--- a/Sources/Handshake/ServerHandshakeState.swift
+++ b/Sources/Handshake/ServerHandshakeState.swift
@@ -25,6 +25,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "ServerHandshakeState")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -35,6 +36,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeState")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 enum ServerHandshakeState {
     /// Ready, but the handshake has not yet started
@@ -263,6 +265,7 @@ enum ServerHandshakeState {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHandshakeState {
     struct IdleState {
@@ -1578,6 +1581,7 @@ extension ServerHandshakeState {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHandshakeState: CustomStringConvertible {
     var description: String {

--- a/Sources/Handshake/ServerHandshakeStateMachine.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachine.swift
@@ -26,6 +26,7 @@ import CryptoKit
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
 
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "ServerHandshakeStateMachine")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -36,6 +37,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeStateMachine")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct SwiftOfferedEPSK {
     let external_identity: Data
@@ -46,11 +48,14 @@ struct SwiftOfferedEPSK {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 typealias externalPSKCompletionCallback = (Int, EPSK?) -> Void
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 typealias externalPSKSelectionCallback = ([SwiftOfferedEPSK], @escaping externalPSKCompletionCallback) -> Void
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct ServerHandshakeStateMachine {
     private var parser = HandshakeMessageParser()
@@ -474,6 +479,7 @@ struct ServerHandshakeStateMachine {
 
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHandshakeStateMachine {
     private mutating func handleReadClientHello(incomingBytes: inout InputBuffer) throws(TLSError) -> StepResult {
@@ -896,6 +902,7 @@ extension ServerHandshakeStateMachine {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHandshakeStateMachine {
     fileprivate enum StepResult {

--- a/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
@@ -26,6 +26,7 @@ import Foundation
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "ServerHandshakeStateMachineConfiguration")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -36,6 +37,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.ServerHandshakeStateMachineConfiguration")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ServerHandshakeStateMachine {
     enum AuthenticationMethod {

--- a/Sources/Handshake/SessionTicket.swift
+++ b/Sources/Handshake/SessionTicket.swift
@@ -23,6 +23,7 @@ import CryptoKit
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "SessionTicket")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -39,6 +40,7 @@ private let logger = Logger(label: "com.apple.security.swifttls.SessionTicket")
 /// ticket age information, and details about the underlying handshake so that resumption can be validated.
 ///
 /// Critically, you can serialize and deserialize session tickets.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct SessionTicket {
     var issued: Date
@@ -218,15 +220,18 @@ struct SessionTicket {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension SessionTicket {
     /// The maximum cache lifetime allowed by RFC 8446.
     static fileprivate let maxLifetime = UInt32(604800)
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension SessionTicket: Equatable { }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     mutating func writeLengthPrefixedString(_ string: String) {

--- a/Sources/HandshakeMessageParser.swift
+++ b/Sources/HandshakeMessageParser.swift
@@ -14,6 +14,7 @@
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "HandshakeMessageParser")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -24,6 +25,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.HandshakeMessageParser")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct HandshakeMessageParser {
     private var bufferedBytes: ByteBuffer?
@@ -184,6 +186,7 @@ struct HandshakeMessageParser {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension HandshakeMessageParser {
     struct ParseResult {

--- a/Sources/InputBuffer.swift
+++ b/Sources/InputBuffer.swift
@@ -19,6 +19,7 @@
 /// a client, such as incoming network data. It is non-copyable to ensure that
 /// it is always clear which code is actively reading the data, preventing
 /// mistakes where the same data is processed multiple times unnecessarily.
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct InputBuffer: ~Escapable, ~Copyable {
     /// Reference to the underlying storage that we're reading from.
@@ -46,6 +47,7 @@ struct InputBuffer: ~Escapable, ~Copyable {
 }
 
 // MARK: Reading
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     /// Reads the given number of bytes from the input buffer.
@@ -214,6 +216,7 @@ extension InputBuffer {
 }
 
 // MARK: Tentative reading
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     /// Execute the given body to allow it to read from this split
@@ -240,6 +243,7 @@ extension InputBuffer {
 }
 
 // MARK: Seeking
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     /// Seek to a specific position.
@@ -250,6 +254,7 @@ extension InputBuffer {
 }
 
 // MARK: Copying out data
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     /// Copies the bytes from the buffer into the given raw output span.

--- a/Sources/KeyExchange.swift
+++ b/Sources/KeyExchange.swift
@@ -17,15 +17,18 @@ import Foundation
 #endif
 #if canImport(CryptoKit)
 import CryptoKit
+// Availability due to `CryptoKit`'s `SymmetricKey`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 typealias SymmetricKey = CryptoKit.SymmetricKey
 #elseif canImport(Crypto)
 @preconcurrency import Crypto
+// Availability due to `CryptoKit`'s `SymmetricKey`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 typealias SymmetricKey = Crypto.SymmetricKey
 #endif
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `SymmetricKey`
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 protocol EphemeralPrivateKey {
     var namedGroup: NamedGroup { get }
     var publicKeyData: Data { get }
@@ -33,6 +36,7 @@ protocol EphemeralPrivateKey {
     func decap(ciphertextData: Data) throws(TLSError) -> SymmetricKey
 }
 
+// Availability due to `CryptoKit`'s `MLKEM768`
 @available(SwiftTLS 0.1.0, *)
 enum GeneratedEphemeralPrivateKey: EphemeralPrivateKey {
     var namedGroup: NamedGroup {
@@ -88,7 +92,8 @@ enum GeneratedEphemeralPrivateKey: EphemeralPrivateKey {
     case X25519MLKEM768(X25519MLKEM768EphemeralKey)
 }
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `Curve25519`
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct Curve25519EphemeralKey: EphemeralPrivateKey {
     var privateKey: Curve25519.KeyAgreement.PrivateKey
 
@@ -120,7 +125,8 @@ struct Curve25519EphemeralKey: EphemeralPrivateKey {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `P384`
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct P384EphemeralKey: EphemeralPrivateKey {
     typealias T = P384.KeyAgreement.PrivateKey
     var privateKey: P384.KeyAgreement.PrivateKey
@@ -153,6 +159,7 @@ struct P384EphemeralKey: EphemeralPrivateKey {
     }
 }
 
+// Availability due to `CryptoKit`'s `MLKEM768`
 @available(SwiftTLS 0.1.0, *)
 struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
     var privateKeyA: Curve25519.KeyAgreement.PrivateKey
@@ -221,6 +228,7 @@ struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
     }
 }
 
+// Availability due to `CryptoKit`'s `MLKEM768`
 @available(SwiftTLS 0.1.0, *)
 func generateEphemeralKeyForNamedGroup(_ group: NamedGroup) -> GeneratedEphemeralPrivateKey? {
     switch group {
@@ -238,6 +246,7 @@ func generateEphemeralKeyForNamedGroup(_ group: NamedGroup) -> GeneratedEphemera
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension SymmetricKey {
     init(_copying bytes: RawSpan) {

--- a/Sources/Protocol Atoms/Alert.swift
+++ b/Sources/Protocol Atoms/Alert.swift
@@ -155,6 +155,7 @@ extension Alert: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readAlert() -> Alert? {
@@ -167,6 +168,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
+++ b/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
@@ -18,6 +18,7 @@ import Foundation
 
 typealias ApplicationLayerProtocol = String
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readApplicationLayerProtocol() -> ApplicationLayerProtocol? {
@@ -34,6 +35,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/CertificateType.swift
+++ b/Sources/Protocol Atoms/CertificateType.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public struct CertificateType: RawRepresentable, Sendable {
     public var rawValue: UInt8
 
@@ -22,16 +21,13 @@ public struct CertificateType: RawRepresentable, Sendable {
     }
 }
 
-@available(SwiftTLS 0.1.0, *)
 extension CertificateType {
     public static let x509 = CertificateType(rawValue: 0)
     public static let rawPublicKey = CertificateType(rawValue: 2)
 }
 
-@available(SwiftTLS 0.1.0, *)
 extension CertificateType: Hashable { }
 
-@available(SwiftTLS 0.1.0, *)
 extension CertificateType: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -45,6 +41,7 @@ extension CertificateType: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readCertificateType() -> CertificateType? {
@@ -52,6 +49,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/CipherSuite.swift
+++ b/Sources/Protocol Atoms/CipherSuite.swift
@@ -43,6 +43,7 @@ extension CipherSuite: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readCipherSuite() -> CipherSuite? {
@@ -50,6 +51,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/ContentType.swift
+++ b/Sources/Protocol Atoms/ContentType.swift
@@ -49,6 +49,7 @@ extension ContentType: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readContentType() -> ContentType? {
@@ -56,6 +57,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/HandshakeType.swift
+++ b/Sources/Protocol Atoms/HandshakeType.swift
@@ -67,6 +67,7 @@ extension HandshakeType: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readHandshakeType() -> HandshakeType? {
@@ -74,6 +75,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/LegacySessionID.swift
+++ b/Sources/Protocol Atoms/LegacySessionID.swift
@@ -14,6 +14,7 @@
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "Handshake")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -24,6 +25,7 @@ import Logging
 private let logger = Logger(label: "com.apple.security.swifttls.Handshake")
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct LegacySessionID {
     fileprivate var bytes: (UInt64, UInt64, UInt64, UInt64)
@@ -58,6 +60,7 @@ struct LegacySessionID {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension LegacySessionID: Hashable {
     static func ==(lhs: LegacySessionID, rhs: LegacySessionID) -> Bool {
@@ -75,6 +78,7 @@ extension LegacySessionID: Hashable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readLegacySessionID() throws(TLSError) -> LegacySessionID? {
@@ -91,6 +95,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/NamedGroup.swift
+++ b/Sources/Protocol Atoms/NamedGroup.swift
@@ -63,6 +63,7 @@ extension NamedGroup: CustomStringConvertible {
 
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readNamedGroup() -> NamedGroup? {
@@ -70,6 +71,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/ProtocolVersion.swift
+++ b/Sources/Protocol Atoms/ProtocolVersion.swift
@@ -51,6 +51,7 @@ extension ProtocolVersion: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readProtocolVersion() -> ProtocolVersion? {
@@ -58,6 +59,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/Random.swift
+++ b/Sources/Protocol Atoms/Random.swift
@@ -49,6 +49,7 @@ extension Random: Hashable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readRandom() -> Random? {
@@ -56,6 +57,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/Protocol Atoms/SignatureScheme.swift
+++ b/Sources/Protocol Atoms/SignatureScheme.swift
@@ -45,6 +45,7 @@ extension SignatureScheme: CustomStringConvertible {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension InputBuffer {
     mutating func readSignatureScheme() -> SignatureScheme? {
@@ -52,6 +53,7 @@ extension InputBuffer {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     @discardableResult

--- a/Sources/SwiftTLSProtocol.swift
+++ b/Sources/SwiftTLSProtocol.swift
@@ -22,6 +22,7 @@ import CryptoKit
 #endif
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
+// Availability due to `os.log`'s `Logger`
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 private let logger = Logger(subsystem: "com.apple.security.swifttls", category: "SwiftTLSProtocol")
 #elseif SWIFTTLS_EMBEDDED || SWIFTTLS_DRIVERKIT
@@ -33,7 +34,6 @@ private let logger = Logger(label: "com.apple.security.swifttls.SwiftTLSProtocol
 #endif
 
 @_spi(SwiftTLSProtocol)
-@available(SwiftTLS 0.1.0, *)
 public enum SwiftTLSError: Error, Equatable {
     case unsupportedOptions
     case invalidServerPrivateKey
@@ -42,7 +42,8 @@ public enum SwiftTLSError: Error, Equatable {
 }
 
 @_spi(SwiftTLSOptions)
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `SecureEnclave.P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 public struct SwiftTLSOptions {
     @frozen public enum EncryptionLevel: CustomDebugStringConvertible {
         case initial
@@ -150,7 +151,8 @@ public struct SwiftTLSOptions {
 
 // MARK: Common helper functions
 
-@available(SwiftTLS 0.1.0, *)
+// Availability due to `CryptoKit`'s `SecureEnclave.P256.Signing.PrivateKey`
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 fileprivate extension CipherSuite {
     static func convertArray(_ input: [SwiftTLSOptions.CipherSuite]?) -> [CipherSuite]? {
         guard let input else { return nil }
@@ -165,6 +167,7 @@ fileprivate extension CipherSuite {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 fileprivate func epskFromSwiftTLSOptions(_ options: SwiftTLSOptions) throws(SwiftTLSError) -> EPSK? {
     var epsk: EPSK? = nil
@@ -184,6 +187,7 @@ fileprivate func epskFromSwiftTLSOptions(_ options: SwiftTLSOptions) throws(Swif
     return epsk
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 fileprivate func clientStateMachineFromTLSOptions(options: SwiftTLSOptions, forQUIC: Bool = true, latestError: inout LatestError?) throws(SwiftTLSError) -> HandshakeStateMachine {
     guard let applicationProtocols = options.applicationProtocols else {
@@ -289,6 +293,7 @@ fileprivate func clientStateMachineFromTLSOptions(options: SwiftTLSOptions, forQ
 
 #if !SWIFTTLS_CLIENT_ONLY
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 fileprivate func serverStateMachineFromTLSOptions(options: SwiftTLSOptions, forQUIC: Bool = true) throws(SwiftTLSError) -> ServerHandshakeStateMachine {
     var keys: [P256.Signing.PublicKey]? = nil
@@ -423,6 +428,7 @@ fileprivate func errorCodeFromLatestError(_ latestError: LatestError?) -> Int32 
 // MARK: QUIC Handshakers
 
 @_spi(SwiftTLSProtocol)
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 public class SwiftTLSHandshaker {
     public var receivedSessionTickets = [[UInt8]]()
@@ -530,6 +536,7 @@ public class SwiftTLSHandshaker {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class SwiftTLSClientHandshaker: SwiftTLSHandshaker {
     var stateMachine: HandshakeStateMachine?
@@ -654,6 +661,7 @@ class SwiftTLSClientHandshaker: SwiftTLSHandshaker {
 
 #if !SWIFTTLS_CLIENT_ONLY
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class SwiftTLSServerHandshaker: SwiftTLSHandshaker {
     var stateMachine: ServerHandshakeStateMachine?

--- a/Sources/TLSMessageSerializer.swift
+++ b/Sources/TLSMessageSerializer.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 struct TLSMessageSerializer {
     init() { }

--- a/Tests/SwiftTLSTests/ExtensionParsingTests.swift
+++ b/Tests/SwiftTLSTests/ExtensionParsingTests.swift
@@ -23,6 +23,7 @@ import CryptoKit
 #endif
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class ExtensionParsingTests: XCTestCase {
     /// Handy-dandy temporary key
@@ -1247,6 +1248,7 @@ class ExtensionParsingTests: XCTestCase {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     mutating func readExtension(messageType: HandshakeType, helloRetryRequest: Bool) throws(TLSError) -> Extension? {

--- a/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
+++ b/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
@@ -22,6 +22,7 @@ import CryptoKit
 @testable import SwiftTLS
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class ExternalPreSharedKeyTests: XCTestCase {
     func testPSKImporterInterface() throws {

--- a/Tests/SwiftTLSTests/HandshakeStateMachineCallbackTests.swift
+++ b/Tests/SwiftTLSTests/HandshakeStateMachineCallbackTests.swift
@@ -29,6 +29,7 @@ import CryptoKit
 import Security
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 final class ClientCallbackFixtures: Sendable {
     let serverSigningKey: P256.Signing.PrivateKey
@@ -153,6 +154,7 @@ final class ClientCallbackFixtures: Sendable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class HandshakeStateMachineCallbackTests: XCTestCase {
 

--- a/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
@@ -23,6 +23,7 @@ import CryptoKit
 #endif
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class HandshakeStateMachineTests: XCTestCase {
 
@@ -2158,6 +2159,7 @@ class HandshakeStateMachineTests: XCTestCase {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ClientHello {
 
@@ -2242,6 +2244,7 @@ extension ClientHello {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension Optional where Wrapped == PartialHandshakeResult {
     enum EncryptionLevelType {
@@ -2297,6 +2300,7 @@ func assertNewEncryptionLevel(_ level: EncryptionLevelType, _ readOrWrite: ReadO
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension PartialHandshakeResult {
     func assertNewEncryptionLevel(_ level: Optional<PartialHandshakeResult>.EncryptionLevelType, _ readOrWrite: Optional<PartialHandshakeResult>.ReadOrWrite, file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/SwiftTLSTests/InputBufferTests.swift
+++ b/Tests/SwiftTLSTests/InputBufferTests.swift
@@ -18,6 +18,7 @@ import XCTest
 @testable import SwiftTLS
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class InputBufferTests: XCTestCase {
     // MARK: - Basic properties

--- a/Tests/SwiftTLSTests/KeyScheduleTests.swift
+++ b/Tests/SwiftTLSTests/KeyScheduleTests.swift
@@ -29,6 +29,7 @@ import CryptoKit
 /// This does not validate the underlying HKDF implementation because that's owned by CryptoKit.
 ///
 /// These tests use ECDHE keys that are not necessarily supported in the underlying implementation. This doesn't matter!
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 final class KeyScheduleTests: XCTestCase {
     func test1RTTExample() throws {
@@ -88,6 +89,7 @@ final class KeyScheduleTests: XCTestCase {
 }
 
 // MARK: Static data
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension KeyScheduleTests {
     static let oneRTTClientX25519Key = try! Curve25519.KeyAgreement.PrivateKey(
@@ -534,7 +536,6 @@ extension KeyScheduleTests {
     )
 }
 
-@available(SwiftTLS 0.1.0, *)
 struct FrozenInTimeClock: SwiftTLSClock {
     var time: Date
 

--- a/Tests/SwiftTLSTests/ProtocolAtomParsingTests.swift
+++ b/Tests/SwiftTLSTests/ProtocolAtomParsingTests.swift
@@ -18,6 +18,7 @@ import XCTest
 #endif
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class ProtocolAtomParsingTests: XCTestCase {
     var buffer: ByteBuffer!

--- a/Tests/SwiftTLSTests/RoundTripParserTests.swift
+++ b/Tests/SwiftTLSTests/RoundTripParserTests.swift
@@ -18,6 +18,7 @@ import XCTest
 #endif
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class RoundTripParserTests: XCTestCase {
     private func roundTripTest_oneShot(_ message: HandshakeMessage) throws {
@@ -230,6 +231,7 @@ class RoundTripParserTests: XCTestCase {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 extension ByteBuffer {
     init(_ string: String) {

--- a/Tests/SwiftTLSTests/ServerHandshakeStateMachineCallbackTests.swift
+++ b/Tests/SwiftTLSTests/ServerHandshakeStateMachineCallbackTests.swift
@@ -29,6 +29,7 @@ import CryptoKit
 import Security
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 final class ServerCallbackFixtures: Sendable {
     let serverSigningKey: P256.Signing.PrivateKey
@@ -261,6 +262,7 @@ final class ServerCallbackFixtures: Sendable {
     }
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class ServerHandshakeStateMachineCallbackTests: XCTestCase {
 

--- a/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
@@ -48,6 +48,7 @@ enum ErrorLocation {
     case readClientFinished
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class ServerHandshakeStateMachineTests: XCTestCase {
     override func setUp() {

--- a/Tests/SwiftTLSTests/SessionTicketTests.swift
+++ b/Tests/SwiftTLSTests/SessionTicketTests.swift
@@ -26,6 +26,7 @@ import CryptoKit
 #endif
 
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 final class SessionTicketTests: XCTestCase {
     // A helper function that lets us tweak one parameter at a time.

--- a/Tests/SwiftTLSTests/TestUtil.swift
+++ b/Tests/SwiftTLSTests/TestUtil.swift
@@ -25,6 +25,7 @@ import CryptoKit
 import Foundation
 #endif
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 var goodClientHello: ClientHello {
   let ephemeralKey = P384EphemeralKey()
@@ -51,6 +52,7 @@ var goodClientHello: ClientHello {
   )
 }
 
+// Availability due to `RawSpan`
 @available(SwiftTLS 0.1.0, *)
 class TestConfigurationGenerator {
     let serverSigningKey = P256.Signing.PrivateKey()


### PR DESCRIPTION
…tions

Every `@available` annotation in `Sources/` and `Tests/` now carries a `// Availability due to ...` comment naming the underlying type or feature that drives the OS floor (e.g. `Swift`'s `RawSpan`, `os.log`'s `Logger`, `CryptoKit`'s `P256.Signing.PublicKey`, `CryptoKit`'s `MLKEM768`). Reading the source no longer requires inferring why each guard is there.

Use the actual binding type's availability instead of `SwiftTLS 0.1.0` (= macOS 26+) where it's lower:

* Types whose only OS-bound dependency is `P256.Signing.{PublicKey, PrivateKey}` — `PrivateKey`, `PublicKey`, their conformance extensions, `BackingPrivateKey`, `SwiftTLSOpaqueReferenceKey` — drop to `macOS 11, iOS 14, tvOS 14, watchOS 7, *` (the P256 Apple-CryptoKit floor).
* `struct Curve25519EphemeralKey` in `KeyExchange.swift` drops to `macOS 10.15, iOS 13, tvOS 13, watchOS 6, *` — its body only references `Curve25519`, available at those versions since CryptoKit shipped.

Drop the `@available` entirely on declarations that have no OS-bound dependency:

* `enum LatestError` and `func errorCodeFromLatestError` in `SwiftTLSProtocol.swift` — both reference only stdlib types.
* `public typealias SwiftTLSSignatureScheme` (a `UInt16` alias) and `public typealias SwiftTLSRefKeySignCallback` (a closure over stdlib `Data` and the alias above) in `PrivateKey.swift` — neither references an OS-bound type.
* Various other declarations whose bodies only touch stdlib / NIO core / always-available APIs.