### PR TITLE
Enable strict memory safety

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,8 @@ var targetDependencies = [PackageDescription.Target.Dependency]()
 var settings: [SwiftSetting]? = [
     // Add build settings here
     .enableExperimentalFeature("Lifetimes"),
+    .strictMemorySafety(),
+    .treatWarning("StrictMemorySafety", as: .error),
 ]
 
 #if os(Linux)

--- a/Sources/ArraySpanUtilities.swift
+++ b/Sources/ArraySpanUtilities.swift
@@ -19,9 +19,9 @@ extension Array where Element == UInt8 {
     ///
     /// The span must contain exactly `count` bytes.
     init(copying bytes: RawSpan) {
-        self.init(unsafeUninitializedCapacity: bytes.byteCount) { outputBuffer, initializedCount in
+        unsafe self.init(unsafeUninitializedCapacity: bytes.byteCount) { outputBuffer, initializedCount in
             bytes.withUnsafeBytes { inputBuffer in
-                UnsafeMutableRawBufferPointer(outputBuffer).copyMemory(from: inputBuffer)
+                unsafe UnsafeMutableRawBufferPointer(outputBuffer).copyMemory(from: inputBuffer)
             }
             initializedCount = bytes.byteCount
         }
@@ -38,7 +38,7 @@ extension InlineArray where Element == UInt8 {
         precondition(count == bytes.byteCount)
         self.init { outputSpan in
             for i in 0..<count {
-                outputSpan.append(bytes.unsafeLoad(fromByteOffset: i, as: UInt8.self))
+                outputSpan.append(unsafe bytes.unsafeLoad(fromByteOffset: i, as: UInt8.self))
             }
         }
     }
@@ -49,7 +49,7 @@ extension InlineArray where Element == UInt8 {
 extension Hasher {
     mutating func combine(bytes: RawSpan) {
         bytes.withUnsafeBytes { buffer in
-            self.combine(bytes: buffer)
+            unsafe self.combine(bytes: buffer)
         }
     }
 }
@@ -74,7 +74,7 @@ extension OutputRawSpan {
     /// Appends the contents of the given raw span to this output span.
     mutating func append(contentsOf bytes: RawSpan) {
         for i in 0..<bytes.byteCount {
-            append(bytes.unsafeLoad(fromByteOffset: i, as: UInt8.self))
+            append(unsafe bytes.unsafeLoad(fromByteOffset: i, as: UInt8.self))
         }
     }
 }
@@ -83,6 +83,6 @@ extension OutputRawSpan {
 @available(SwiftTLS 0.1.0, *)
 extension RawSpan {
     subscript(index: Int) -> UInt8 {
-        unsafeLoad(fromByteOffset: index, as: UInt8.self)
+        unsafe unsafeLoad(fromByteOffset: index, as: UInt8.self)
     }
 }

--- a/Sources/ByteBuffer.swift
+++ b/Sources/ByteBuffer.swift
@@ -90,7 +90,7 @@ struct ByteBuffer {
         var networkByteOrder = integer.bigEndian
         withUnsafeBytes(of: &networkByteOrder) {
             precondition($0.count == byteWidth)
-            self.backingData.append(contentsOf: $0)
+            unsafe self.backingData.append(contentsOf: $0)
         }
 
         return byteWidth
@@ -108,7 +108,7 @@ struct ByteBuffer {
         var networkByteOrder = integer.bigEndian
         withUnsafeBytes(of: &networkByteOrder) {
             precondition($0.count == byteWidth)
-            self.backingData.replaceSubrange(index..<endIndex, with: $0)
+            unsafe self.backingData.replaceSubrange(index..<endIndex, with: $0)
         }
 
         return byteWidth
@@ -128,10 +128,10 @@ struct ByteBuffer {
 
         _ = withUnsafeMutableBytes(of: &value) {
             #if canImport(Foundation) && !SWIFTTLS_EMBEDDED
-            self.backingData.copyBytes(to: $0, from: self.readerIndex..<endIndex)
+            unsafe self.backingData.copyBytes(to: $0, from: self.readerIndex..<endIndex)
             #else
             // SwiftSystem Data is missing copyBytes(to: from:)
-            $0.copyBytes(from: self.backingData[self.readerIndex..<endIndex])
+            unsafe $0.copyBytes(from: self.backingData[self.readerIndex..<endIndex])
             #endif
         }
         return IntegerType(bigEndian: value)

--- a/Sources/Cryptography/HKDF+Label.swift
+++ b/Sources/Cryptography/HKDF+Label.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 // Availability due to `CryptoKit`'s `HKDF`
@@ -48,9 +48,9 @@ extension HKDF {
         serializedLabel.append(contentsOf: "tls13 ".utf8)
         serializedLabel.append(contentsOf: label.utf8)
 
-        context.withUnsafeBytes { contextPointer in
+        unsafe context.withUnsafeBytes { contextPointer in
             serializedLabel.append(UInt8(contextPointer.count))
-            serializedLabel.append(contentsOf: contextPointer)
+            unsafe serializedLabel.append(contentsOf: contextPointer)
         }
 
         return Self.expand(pseudoRandomKey: secret, info: serializedLabel, outputByteCount: length)
@@ -67,11 +67,11 @@ extension HKDF {
 
     static func extract(inputKeyMaterial ikm: SymmetricKey, salt: SymmetricKey) -> HashedAuthenticationCode<H> {
         // This wrapper helps us deal with the fact that these types don't neatly fit into what CryptoKit wants.
-        return salt.withUnsafeBytes { saltPointer in
+        return unsafe salt.withUnsafeBytes { saltPointer in
             #if SWIFTTLS_EXCLAVEKIT
-            Self.extract(inputKeyMaterial: ikm, salt: Data(saltPointer))
+            unsafe Self.extract(inputKeyMaterial: ikm, salt: Data(saltPointer))
             #else
-            Self.extract(inputKeyMaterial: ikm, salt: saltPointer)
+            unsafe Self.extract(inputKeyMaterial: ikm, salt: saltPointer)
             #endif
         }
     }

--- a/Sources/Cryptography/HashFunction+Helpers.swift
+++ b/Sources/Cryptography/HashFunction+Helpers.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 // Availability due to `CryptoKit`'s `HashFunction`
@@ -33,8 +33,8 @@ extension HashFunction {
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HMAC {
     static func authenticationCode<Bytes: ContiguousBytes>(bytes: Bytes, using key: SymmetricKey) -> HashedAuthenticationCode<H> {
-        return bytes.withUnsafeBytes {
-            Self.authenticationCode(for: $0, using: key)
+        return unsafe bytes.withUnsafeBytes {
+            unsafe Self.authenticationCode(for: $0, using: key)
         }
     }
 }

--- a/Sources/Cryptography/KeyScheduler.swift
+++ b/Sources/Cryptography/KeyScheduler.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
@@ -518,7 +518,7 @@ fileprivate struct SessionKeyManager<HF: HashFunction> {
         var transcriptHasher = HF()
         transcriptHasher.update(data: transcript.readableBytesView)
         let hash = transcriptHasher.finalize()
-        hash.withUnsafeBytes { _ = buffer.writeBytes($0) }
+        unsafe hash.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
         return buffer
     }
 
@@ -893,7 +893,7 @@ extension SessionKeyManager.State {
             buffer.writeInteger(UInt8(0))
 
             let hash = self.transcriptHasher.finalize()
-            hash.withUnsafeBytes { _ = buffer.writeBytes($0) }
+            unsafe hash.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
             return buffer
         }
     }
@@ -956,7 +956,7 @@ extension SessionKeyManager.State {
             buffer.writeInteger(UInt8(0))
 
             let hash = self.transcriptHasher.finalize()
-            hash.withUnsafeBytes { _ = buffer.writeBytes($0) }
+            unsafe hash.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
             return buffer
         }
 

--- a/Sources/Cryptography/PrivateKey.swift
+++ b/Sources/Cryptography/PrivateKey.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 /// A generic wrapper over the supported private-key types.

--- a/Sources/Cryptography/PublicKey.swift
+++ b/Sources/Cryptography/PublicKey.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 /// An opaque wrapper around the supported public-key types.

--- a/Sources/DataUtilities.swift
+++ b/Sources/DataUtilities.swift
@@ -25,7 +25,7 @@ extension Data {
             self = Data()
         } else {
             self = bytes.withUnsafeBytes { buffer in
-                Data(
+                unsafe Data(
                     UnsafeBufferPointer<UInt8>(
                         start: buffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
                         count: buffer.count
@@ -38,7 +38,7 @@ extension Data {
     /// Appends the contents of the given span to this `Data` instance.
     mutating func append(contentsOf bytes: RawSpan) {
         bytes.withUnsafeBytes { buffer in
-            self.append(contentsOf: buffer)
+            unsafe self.append(contentsOf: buffer)
         }
     }
 
@@ -46,9 +46,9 @@ extension Data {
     ///
     /// Used as a workaround for SwiftSystem's `Data` missing the `bytes` property.
     func withBytes<R, E: Error>(_ body: (RawSpan) throws(E) -> R) throws(E) -> R {
-        let result: Result<R, E> = self.withUnsafeBytes { bufferPointer in
+        let result: Result<R, E> = unsafe self.withUnsafeBytes { bufferPointer in
             do throws(E) {
-                return .success(try body(bufferPointer.bytes))
+                return .success(try body(unsafe bufferPointer.bytes))
             } catch {
                 return .failure(error)
             }
@@ -62,7 +62,8 @@ extension Data {
 //
 // Use this wrapper to turn an UnsafeRawBufferPointer into something that conforms to
 // DataProtocol. This whole type should go away once the issue is fixed.
-struct UnsafeRawBufferPointerWrapper: DataProtocol, RandomAccessCollection, ContiguousBytes {
+@unsafe
+struct UnsafeRawBufferPointerWrapper: @unsafe DataProtocol, @unsafe RandomAccessCollection, ContiguousBytes {
     var wrapped: UnsafeRawBufferPointer
 
     typealias Element = UInt8
@@ -70,25 +71,25 @@ struct UnsafeRawBufferPointerWrapper: DataProtocol, RandomAccessCollection, Cont
     typealias Regions = CollectionOfOne<UnsafeRawBufferPointerWrapper>
 
     var regions: CollectionOfOne<UnsafeRawBufferPointerWrapper> {
-        CollectionOfOne(self)
+        unsafe CollectionOfOne(self)
     }
 
-    var startIndex: Int { wrapped.startIndex }
-    var endIndex: Int { wrapped.endIndex }
+    var startIndex: Int { unsafe wrapped.startIndex }
+    var endIndex: Int { unsafe wrapped.endIndex }
 
     subscript(index: Int) -> UInt8 {
         get {
-            wrapped[index]
+            unsafe wrapped[index]
         }
     }
 
     #if $Embedded
     func withUnsafeBytes<R, E>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
-        try wrapped.withUnsafeBytes(body)
+        try unsafe wrapped.withUnsafeBytes(body)
     }
     #else
     func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        try wrapped.withUnsafeBytes(body)
+        try unsafe wrapped.withUnsafeBytes(body)
     }
     #endif
 }

--- a/Sources/Handshake/ExternalPreSharedKey.swift
+++ b/Sources/Handshake/ExternalPreSharedKey.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 // Availability due to `RawSpan`

--- a/Sources/Handshake/HandshakeState.swift
+++ b/Sources/Handshake/HandshakeState.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT

--- a/Sources/Handshake/HandshakeStateMachine.swift
+++ b/Sources/Handshake/HandshakeStateMachine.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT

--- a/Sources/Handshake/HandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/HandshakeStateMachineConfiguration.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT

--- a/Sources/Handshake/PartialHandshakeResult.swift
+++ b/Sources/Handshake/PartialHandshakeResult.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 // Availability due to `RawSpan`

--- a/Sources/Handshake/PeerCertificateBundle.swift
+++ b/Sources/Handshake/PeerCertificateBundle.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
@@ -308,7 +308,7 @@ extension InputBuffer {
         case 0:
             let key = try TLSError.wrappingCryptoError { () throws(CryptoKitMetaError) in try self.readLengthPrefixed { buffer throws(CryptoKitMetaError) in
                 try buffer.bytes.withUnsafeBytes { (bytes) throws(CryptoKitMetaError) in
-                    try P256.Signing.PublicKey(rawRepresentation: bytes)
+                    try unsafe P256.Signing.PublicKey(rawRepresentation: bytes)
                 }
             } }
             guard let key = key else {

--- a/Sources/Handshake/ServerHandshakeState.swift
+++ b/Sources/Handshake/ServerHandshakeState.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if !SWIFTTLS_CLIENT_ONLY

--- a/Sources/Handshake/ServerHandshakeStateMachine.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachine.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if !SWIFTTLS_CLIENT_ONLY

--- a/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
+++ b/Sources/Handshake/ServerHandshakeStateMachineConfiguration.swift
@@ -15,7 +15,7 @@
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Foundation) && !SWIFTTLS_EMBEDDED

--- a/Sources/Handshake/SessionTicket.swift
+++ b/Sources/Handshake/SessionTicket.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
@@ -126,8 +126,8 @@ struct SessionTicket {
         buffer.writeLengthPrefixedImmutableBuffer(self.nonce)
         buffer.writeLengthPrefixedImmutableBuffer(self.ticket)
 
-        self.psk.withUnsafeBytes {
-            buffer.writeLengthPrefixedBytes($0)
+        unsafe self.psk.withUnsafeBytes {
+            unsafe buffer.writeLengthPrefixedBytes($0)
         }
 
         buffer.writeInteger(self.maxEarlyDataSize)

--- a/Sources/InputBuffer.swift
+++ b/Sources/InputBuffer.swift
@@ -100,14 +100,14 @@ extension InputBuffer {
         // Copy those bytes into a temporary value.
         let align = MemoryLayout<Value>.alignment
         return withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: align) { valueBuffer in
-            var outputSpan = OutputRawSpan(
+            var outputSpan = unsafe OutputRawSpan(
                 buffer: valueBuffer,
                 initializedCount: 0
             )
             bytes.copy(to: &outputSpan)
-            let bytesWritten = outputSpan.finalize(for: valueBuffer)
+            let bytesWritten = unsafe outputSpan.finalize(for: valueBuffer)
             precondition(bytesWritten == byteCount)
-            return valueBuffer.load(as: Value.self)
+            return unsafe valueBuffer.load(as: Value.self)
         }
     }
 

--- a/Sources/KeyExchange.swift
+++ b/Sources/KeyExchange.swift
@@ -21,7 +21,7 @@ import CryptoKit
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 typealias SymmetricKey = CryptoKit.SymmetricKey
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 // Availability due to `CryptoKit`'s `SymmetricKey`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 typealias SymmetricKey = Crypto.SymmetricKey
@@ -198,8 +198,8 @@ struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
         let secretB = encapResult.sharedSecret
 
         var buffer = ByteBuffer()
-        secretB.withUnsafeBytes { _ = buffer.writeBytes($0) }
-        secretA.withUnsafeBytes { _ = buffer.writeBytes($0) }
+        unsafe secretB.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
+        unsafe secretA.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
         let bytes = buffer.readableBytesView
 
         let ciphertext = encapResult.encapsulated + self.privateKeyA.publicKey.rawRepresentation
@@ -220,8 +220,8 @@ struct X25519MLKEM768EphemeralKey: EphemeralPrivateKey {
         let secretB = try TLSError.wrappingCryptoError { try self.privateKeyB.decapsulate(peerMLKEMKeyBytes) }
 
         var buffer = ByteBuffer()
-        secretB.withUnsafeBytes { _ = buffer.writeBytes($0) }
-        secretA.withUnsafeBytes { _ = buffer.writeBytes($0) }
+        unsafe secretB.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
+        unsafe secretA.withUnsafeBytes { _ = unsafe buffer.writeBytes($0) }
         let bytes = buffer.readableBytesView
 
         return SymmetricKey.init(data: bytes)
@@ -251,7 +251,7 @@ func generateEphemeralKeyForNamedGroup(_ group: NamedGroup) -> GeneratedEphemera
 extension SymmetricKey {
     init(_copying bytes: RawSpan) {
         self = bytes.withUnsafeBytes { buffer in
-            SymmetricKey(data: buffer)
+            unsafe SymmetricKey(data: buffer)
         }
     }
 }

--- a/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
+++ b/Sources/Protocol Atoms/ApplicationLayerProtocol.swift
@@ -30,7 +30,7 @@ extension InputBuffer {
         }
         // Convert RawSpan bytes to String
         return slice.bytes.withUnsafeBytes { buffer in
-            ApplicationLayerProtocol(decoding: buffer, as: UTF8.self)
+            unsafe ApplicationLayerProtocol(decoding: buffer, as: UTF8.self)
         }
     }
 }

--- a/Sources/Protocol Atoms/LegacySessionID.swift
+++ b/Sources/Protocol Atoms/LegacySessionID.swift
@@ -44,7 +44,7 @@ struct LegacySessionID {
         self.bytes = (0, 0, 0, 0)
         withUnsafeMutableBytes(of: &self.bytes) { outputBuffer in
             bytes.withUnsafeBytes { inputBuffer in
-                outputBuffer.copyBytes(from: inputBuffer)
+                unsafe outputBuffer.copyBytes(from: inputBuffer)
             }
         }
         self.length = bytes.byteCount
@@ -102,7 +102,7 @@ extension ByteBuffer {
     mutating func writeLegacySessionID(_ sessionID: LegacySessionID) -> Int {
         return self.writeVariableLengthVector(lengthFieldType: UInt8.self) { buffer in
             return withUnsafeBytes(of: sessionID.bytes) {
-                buffer.writeBytes($0.prefix(sessionID.length))
+                unsafe buffer.writeBytes($0.prefix(sessionID.length))
             }
         }
     }

--- a/Sources/Protocol Atoms/Random.swift
+++ b/Sources/Protocol Atoms/Random.swift
@@ -24,7 +24,7 @@ struct Random {
         precondition(bytes.count == MemoryLayout<Random>.size)
         self.bytes = (0, 0, 0, 0)
         withUnsafeMutableBytes(of: &self.bytes) {
-            $0.copyBytes(from: bytes)
+            unsafe $0.copyBytes(from: bytes)
         }
     }
 }
@@ -64,7 +64,7 @@ extension ByteBuffer {
     mutating func writeRandom(_ random: Random) -> Int {
         return withUnsafeBytes(of: random.bytes) {
             assert($0.count == 32)
-            return self.writeBytes($0)
+            return unsafe self.writeBytes($0)
         }
     }
 }

--- a/Sources/SwiftTLSProtocol.swift
+++ b/Sources/SwiftTLSProtocol.swift
@@ -18,7 +18,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(Darwin) || SWIFTTLS_EXCLAVEKIT
 import os.log
@@ -508,8 +508,8 @@ public class SwiftTLSHandshaker {
             secretKey = secret
         }
 
-        let secretBytes = secretKey.withUnsafeBytes {
-            return [UInt8]($0)
+        let secretBytes = unsafe secretKey.withUnsafeBytes {
+            return unsafe [UInt8]($0)
         }
         return secretBytes
     }

--- a/Tests/SwiftTLSTests/ExtensionParsingTests.swift
+++ b/Tests/SwiftTLSTests/ExtensionParsingTests.swift
@@ -16,7 +16,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable @_spi(SwiftTLSProtocol) import SwiftTLS

--- a/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
+++ b/Tests/SwiftTLSTests/ExternalPreSharedKeyTests.swift
@@ -16,7 +16,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable import SwiftTLS

--- a/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/HandshakeStateMachineTests.swift
@@ -16,7 +16,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable @_spi(SwiftTLSProtocol) import SwiftTLS

--- a/Tests/SwiftTLSTests/InputBufferTests.swift
+++ b/Tests/SwiftTLSTests/InputBufferTests.swift
@@ -539,7 +539,7 @@ class InputBufferTests: XCTestCase {
             _ = input.read(length: 1) // advance past 0x10
 
             withUnsafeTemporaryAllocation(byteCount: 8, alignment: 1) { raw in
-                var output = OutputRawSpan(buffer: raw, initializedCount: 0)
+                var output = unsafe OutputRawSpan(buffer: raw, initializedCount: 0)
                 let written = input.copy(to: &output)
                 XCTAssertEqual(written, 3)
 
@@ -547,10 +547,10 @@ class InputBufferTests: XCTestCase {
                 XCTAssertEqual(input.byteCount, 3)
                 XCTAssertEqual(input.position, 1)
 
-                let finalized = output.finalize(for: raw)
+                let finalized = unsafe output.finalize(for: raw)
                 XCTAssertEqual(finalized, 3)
 
-                let copied = Array(UnsafeBufferPointer(start: raw.baseAddress!.assumingMemoryBound(to: UInt8.self), count: 3))
+                let copied = unsafe Array(UnsafeBufferPointer(start: raw.baseAddress!.assumingMemoryBound(to: UInt8.self), count: 3))
                 XCTAssertEqual(copied, [0x20, 0x30, 0x40])
             }
         }
@@ -561,17 +561,17 @@ class InputBufferTests: XCTestCase {
         buffer.writeBytes([0x01, 0x02, 0x03, 0x04, 0x05])
         buffer.withInputBuffer { input in
             withUnsafeTemporaryAllocation(byteCount: 2, alignment: 1) { raw in
-                var output = OutputRawSpan(buffer: raw, initializedCount: 0)
+                var output = unsafe OutputRawSpan(buffer: raw, initializedCount: 0)
                 let written = input.copy(to: &output)
                 // Capped at the output's free capacity.
                 XCTAssertEqual(written, 2)
                 // Input position is not advanced.
                 XCTAssertEqual(input.position, 0)
 
-                let finalized = output.finalize(for: raw)
+                let finalized = unsafe output.finalize(for: raw)
                 XCTAssertEqual(finalized, 2)
 
-                let copied = Array(UnsafeBufferPointer(start: raw.baseAddress!.assumingMemoryBound(to: UInt8.self), count: 2))
+                let copied = unsafe Array(UnsafeBufferPointer(start: raw.baseAddress!.assumingMemoryBound(to: UInt8.self), count: 2))
                 XCTAssertEqual(copied, [0x01, 0x02])
             }
         }

--- a/Tests/SwiftTLSTests/KeyScheduleTests.swift
+++ b/Tests/SwiftTLSTests/KeyScheduleTests.swift
@@ -16,7 +16,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable @_spi(SwiftTLSProtocol) import SwiftTLS

--- a/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
+++ b/Tests/SwiftTLSTests/ServerHandshakeStateMachineTests.swift
@@ -16,7 +16,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable @_spi(SwiftTLSProtocol) import SwiftTLS

--- a/Tests/SwiftTLSTests/SessionTicketTests.swift
+++ b/Tests/SwiftTLSTests/SessionTicketTests.swift
@@ -19,7 +19,7 @@ import Foundation
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 #if canImport(SwiftTLS) && !SWIFTTLS_BUILTIN_TESTS
 @testable @_spi(SwiftTLSProtocol) import SwiftTLS

--- a/Tests/SwiftTLSTests/SwiftTLSProtocolTests.swift
+++ b/Tests/SwiftTLSTests/SwiftTLSProtocolTests.swift
@@ -19,7 +19,7 @@ import XCTest
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 @available(SwiftTLS 0.1.0, *)

--- a/Tests/SwiftTLSTests/TestUtil.swift
+++ b/Tests/SwiftTLSTests/TestUtil.swift
@@ -18,7 +18,7 @@
 #if canImport(CryptoKit)
 import CryptoKit
 #elseif canImport(Crypto)
-@preconcurrency import Crypto
+@preconcurrency @unsafe import Crypto
 #endif
 
 #if canImport(Foundation) && !SWIFTTLS_EMBEDDED


### PR DESCRIPTION
And add any unsafe keywords needed to fix the build.